### PR TITLE
fix issue #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ ddc requires both Deno and denops.vim.
 
 ```vim
 " Use around source.
-call ddc#custom#global('sources', { '_': ['around] })
+call ddc#custom#global('sources', { '_': ['around'] })
 " Enable default matcher.
 call ddc#custom#source('_', 'matchers', ['matcher_head'])
 


### PR DESCRIPTION
## Problems summary
There is a syntax error in the configuration example written in README.md.
Specifically, the quotation marks are not closed.

more info.
see [https://github.com/Shougo/ddc.vim/issues/5](https://github.com/Shougo/ddc.vim/issues/5)