### PR TITLE
Remove candidates from Context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,7 @@ lint:
 test:
 	deno test --unstable -A ${TS}
 
+format:
+	deno fmt denops
+
 .PHONY: lint test

--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,4 @@ test:
 format:
 	deno fmt denops
 
-.PHONY: lint test
+.PHONY: lint test format

--- a/denops/ddc/base/filter.ts
+++ b/denops/ddc/base/filter.ts
@@ -4,5 +4,9 @@ import { Denops } from "../deps.ts";
 export abstract class BaseFilter {
   name = "";
 
-  abstract filter(denops: Denops, context: Context): Promise<Candidate[]>;
+  abstract filter(
+    denops: Denops,
+    context: Context,
+    candidates: Candidate[],
+  ): Promise<Candidate[]>;
 }

--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -47,15 +47,14 @@ export class Ddc {
     source: BaseSource,
     cdd: Candidate[],
   ): Promise<Candidate[]> {
-    const ctx: Context = Object.assign(context, { candidates: cdd });
-
+    let cs = cdd;
     // Matchers
     for (const key in this.filters) {
       if (!(source.options.matchers.includes(key))) {
         continue;
       }
 
-      ctx.candidates = await this.filters[key].filter(denops, ctx);
+      cs = await this.filters[key].filter(denops, context, cs);
     }
 
     // Sorters
@@ -64,7 +63,7 @@ export class Ddc {
         continue;
       }
 
-      ctx.candidates = await this.filters[key].filter(denops, ctx);
+      cs = await this.filters[key].filter(denops, context, cs);
     }
 
     // Converters
@@ -73,11 +72,10 @@ export class Ddc {
         continue;
       }
 
-      ctx.candidates = await this.filters[key].filter(denops, ctx);
+      cs = await this.filters[key].filter(denops, context, cs);
     }
 
-    for (const key in ctx.candidates) {
-      const candidate = ctx.candidates[key];
+    for (const candidate of cs) {
       candidate.source = source.name;
       candidate.icase = true;
       candidate.equal = true;
@@ -85,6 +83,6 @@ export class Ddc {
         ? `[${candidate.source}] ${candidate.menu}`
         : `[${candidate.source}]`;
     }
-    return ctx.candidates;
+    return cs;
   }
 }

--- a/denops/ddc/filters/matcher_head.ts
+++ b/denops/ddc/filters/matcher_head.ts
@@ -8,12 +8,16 @@ function lastWord(input: string): string {
 }
 
 export class Filter extends BaseFilter {
-  filter(_denops: Denops, context: Context): Promise<Candidate[]> {
+  filter(
+    _denops: Denops,
+    context: Context,
+    candidates: Candidate[],
+  ): Promise<Candidate[]> {
     const completeStr = lastWord(context.input);
-    const candidates = context.candidates.filter(
+    const filtered = candidates.filter(
       (candidate) => candidate.word.startsWith(completeStr),
     );
-    return Promise.resolve(candidates);
+    return Promise.resolve(filtered);
   }
 }
 

--- a/denops/ddc/types.ts
+++ b/denops/ddc/types.ts
@@ -1,8 +1,10 @@
 export { BaseSource } from "./base/source.ts";
 export { BaseFilter } from "./base/filter.ts";
 
+export type SourceName = string;
+
 export interface Custom {
-  source: Record<string, SourceOptions>;
+  source: Record<SourceName, SourceOptions>;
   option: DdcOptions;
 }
 
@@ -16,11 +18,11 @@ export interface Candidate {
   userData?: unknown;
   icase?: boolean;
   equal?: boolean;
-  source?: string;
+  source?: SourceName;
 }
 
 export interface DdcOptions {
-  sources: Record<string, string[]>;
+  sources: Record<string, SourceName[]>;
 }
 
 export const defaultDdcOptions: DdcOptions = {
@@ -28,7 +30,6 @@ export const defaultDdcOptions: DdcOptions = {
 };
 
 export interface Context {
-  candidates: Candidate[];
   input: string;
   options: DdcOptions;
 }


### PR DESCRIPTION
## Changes
* add `format` to Makefile
  - It's inconvenient to only check format and not know how to do format
* create {Filter,Source}Arg for register{Filter,Source}
  - It is defined by ddc, so it can be typed
  - `as FilterArg` will convince the type system, but will not be validated
  - But `ensureObject as Record<string, unknown>` also returns undefined if the key is missing, so there is no difference
* remove candidates from Context
  - It is difficult to make sense of the `context.candidates` during source processing
  - Since we're using the strong word Context, it's probably easier to handle something that won't change during the entire process from start
  - It would be inconvenient to change to stream
  - Filter now explicitly takes candidates and returns candidates

## 以下はいじってませんが後々ご検討ください。
### 設定について
* customとregisterを構成しなおしてインターフェイス統治してあげる必要を感じる
  - 例えばregisterSourceみると登録時のcustomを見ていて登録順に敏感になってるのでたぶんそういうところが難しい
* startのたびに設定同期するのはもったい無い気がする
  - Ddcがオプションを持っているのにstartでcontextを取得して渡している
* 実行前に設定して実行中変更されない値には、私ならCustomよりはconfig, settings, preferencesと名付けたい

### Candidateについて
現状のCandidateはvim scriptのため計算結果含め全てをシリアライズした型ですが、そのフィールドは誰によって計算されるかによって別れているはずです。
具体的には、私には見分けがつかないのですが、
ソースがもたせるべきフィールド, フィルタがもたせるべきフィールド, ddcがもたせるべきフィールド, 他のフィールドからcandidate自身で計算可能なフィールド
に分かれているはずです。
これら全ての型をつくるのは面倒ですが少なくとも2個くらい、例えば、ソースとフィルタが吐くCandidate型, 全てのフィールドを持つシリアライズ用Candidate型の2つに分けてもいいかと思います。
詳しくなくても型通りにつくれるのが親切なインターフェイスなのでご一考ください。


宗派の違いでしかないところもあるので黙っていようかと思っていましたが、インターフェイスへの影響もあるので口出ししました。手を動かすより口出すほうが多くなってしまいましたが、 必要なところだけ取り込んでください。
ご検討お願いします。
