### PR TITLE
設定再構成

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 TS=$(shell find denops -name "*.ts")
+TSTEST=$(shell grep -rl "Deno.test" denops)
 
 lint:
 	vint --version
@@ -9,7 +10,7 @@ lint:
 	deno lint --unstable denops
 
 test:
-	deno test --unstable -A ${TS}
+	deno test --unstable -A ${TSTEST}
 
 format:
 	deno fmt denops

--- a/README.md
+++ b/README.md
@@ -82,12 +82,13 @@ ddc requires both Deno and denops.vim.
 
 ```vim
 " Use around source.
-call ddc#custom#global('sources', { '_': ['around'] })
+call ddc#custom#patch_global('sources', ['around'])
 " Enable default matcher.
-call ddc#custom#source('_', 'matchers', ['matcher_head'])
-
-" Change source mark.
-call ddc#custom#source('around', 'mark', ['A'])
+call ddc#custom#patch_global('defaultMatchers', ['matcher_head'])
+" Change source options
+call ddc#custom#patch_global('sourceOptions', {
+      \ 'around': {'matchers': ['matcher_head'], 'mark': 'A'}
+      \ })
 
 " Use ddc.
 call ddc#enable()

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ ddc requires both Deno and denops.vim.
 " Use around source.
 call ddc#custom#patch_global('sources', ['around'])
 " Enable default matcher.
-call ddc#custom#patch_global('defaultMatchers', ['matcher_head'])
+call ddc#custom#patch_global('sourceOptions', {
+      \ '_': {'matchers': ['matcher_head']}
+      \ }
 " Change source options
 call ddc#custom#patch_global('sourceOptions', {
       \ 'around': {'matchers': ['matcher_head'], 'mark': 'A'}

--- a/README.md
+++ b/README.md
@@ -86,23 +86,23 @@ ddc requires both Deno and denops.vim.
 call ddc#custom#patch_global('sources', ['around'])
 " Enable default matcher.
 call ddc#custom#patch_global('sourceOptions', {
-      \ '_': {'matchers': ['matcher_head']}
+      \ '_': {'matchers': ['matcher_head']},
       \ }
 " Change source options
 call ddc#custom#patch_global('sourceOptions', {
-      \ 'around': {'matchers': ['matcher_head'], 'mark': 'A'}
+      \ 'around': {'matchers': ['matcher_head'], 'mark': 'A'},
       \ })
 call ddc#custom#patch_global('sourceParams', {
-      \ 'around': {'maxSize': 500}
+      \ 'around': {'maxSize': 500},
       \ })
 
 " Customize settings on a filetype
 call ddc#custom#patch_filetype(['c', 'cpp'], 'sources', ['around', 'clangd'])
 call ddc#custom#patch_filetype(['c', 'cpp'], 'sourceOptions', {
-      \ 'clangd': {'mark': 'C'}
+      \ 'clangd': {'mark': 'C'},
       \ }
 call ddc#custom#patch_filetype('markdown', 'sourceParams', {
-      \ 'around': {'maxSize': 100}
+      \ 'around': {'maxSize': 100},
       \ })
 
 " Use ddc.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ ddc requires both Deno and denops.vim.
 ## Configuration
 
 ```vim
+" Customize global settings
 " Use around source.
 call ddc#custom#patch_global('sources', ['around'])
 " Enable default matcher.
@@ -90,6 +91,18 @@ call ddc#custom#patch_global('sourceOptions', {
 " Change source options
 call ddc#custom#patch_global('sourceOptions', {
       \ 'around': {'matchers': ['matcher_head'], 'mark': 'A'}
+      \ })
+call ddc#custom#patch_global('sourceParams', {
+      \ 'around': {'maxSize': 500}
+      \ })
+
+" Customize settings on a filetype
+call ddc#custom#patch_filetype(['c', 'cpp'], 'sources', ['around', 'clangd'])
+call ddc#custom#patch_filetype(['c', 'cpp'], 'sourceOptions', {
+      \ 'clangd': {'mark': 'C'}
+      \ }
+call ddc#custom#patch_filetype('markdown', 'sourceParams', {
+      \ 'around': {'maxSize': 100}
       \ })
 
 " Use ddc.

--- a/autoload/ddc.vim
+++ b/autoload/ddc.vim
@@ -4,7 +4,7 @@
 " License: MIT license
 "=============================================================================
 
-let s:script = fnamemodify(expand('<sfile>'), ':h:h')
+let s:root_dir = fnamemodify(expand('<sfile>'), ':h:h')
 
 function! ddc#enable() abort
   if v:version < 802 && !has('nvim-0.5')
@@ -17,7 +17,7 @@ function! ddc#enable() abort
   augroup ddc
     autocmd!
     autocmd User DenopsReady call denops#plugin#register('ddc',
-          \ denops#util#join_path(s:script, 'denops', 'ddc', 'app.ts'))
+          \ denops#util#join_path(s:root_dir, 'denops', 'ddc', 'app.ts'))
   augroup END
 endfunction
 

--- a/autoload/ddc.vim
+++ b/autoload/ddc.vim
@@ -45,7 +45,7 @@ function! ddc#register_source(dict) abort
           \ )
   else
     call denops#request_async(
-    \ 'ddc', 'registerSource', [a:dict], {-> v:null}, {-> v:null})
+          \ 'ddc', 'registerSource', [a:dict], {-> v:null}, {-> v:null})
   endif
 endfunction
 function! ddc#register_filter(dict) abort

--- a/autoload/ddc/custom.vim
+++ b/autoload/ddc/custom.vim
@@ -4,42 +4,76 @@
 " License: MIT license
 "=============================================================================
 
-function! ddc#custom#_get() abort
-  if !exists('s:custom')
-    call ddc#custom#_init()
-  endif
-
-  return s:custom
-endfunction
-
-function! ddc#custom#_init() abort
-  let s:custom = {}
-  let s:custom.source = {}
-  let s:custom.source._ = {}
-  let s:custom.option = {}
-endfunction
-
-function! ddc#custom#source(source_name, name_or_dict, ...) abort
-  let custom = ddc#custom#_get().source
-
-  for key in ddc#util#split(a:source_name)
-    if !has_key(custom, key)
-      let custom[key] = {}
-    endif
-
-    call s:set_custom(custom[key], a:name_or_dict, get(a:000, 0, ''))
-  endfor
-endfunction
-
-function! ddc#custom#global(name_or_dict, ...) abort
-  let custom = ddc#custom#_get().option
-  call s:set_custom(custom, a:name_or_dict, get(a:000, 0, ''))
-endfunction
-
-function! s:set_custom(dest, name_or_dict, value) abort
-  if type(a:name_or_dict) == v:t_dict
-    call extend(a:dest, a:name_or_dict)
+function! s:patch_global(dict) abort
+  if !exists('g:ddc#_initialized')
+    execute printf('autocmd User DDCReady call ' .
+          \ 'denops#request_async("ddc", "patchGlobal", [%s], '.
+          \ '{-> v:null}, {-> v:null})', a:dict
+          \ )
   else
-    let a:dest[a:name_or_dict] = a:value
+    call denops#request_async(
+    \ 'ddc', 'patchGlobal', [a:dict], {-> v:null}, {-> v:null})
   endif
+endfunction
+
+function! s:patch_filetype(ft, dict) abort
+  if !exists('g:ddc#_initialized')
+    execute printf('autocmd User DDCReady call ' .
+          \ 'denops#request_async("ddc", "patchFiletype", ["%s", %s], '.
+          \ '{-> v:null}, {-> v:null})', a:ft, a:dict
+          \ )
+  else
+    call denops#request_async(
+    \ 'ddc', 'patchFiletype', [a:ft, a:dict], {-> v:null}, {-> v:null})
+  endif
+endfunction
+
+function! s:patch_buffer(bufnr, dict) abort
+  if !exists('g:ddc#_initialized')
+    execute printf('autocmd User DDCReady call ' .
+          \ 'denops#request_async("ddc", "patchBuffer", [%s, %s], '.
+          \ '{-> v:null}, {-> v:null})', a:bufnr, a:dict
+          \ )
+  else
+    call denops#request_async(
+    \ 'ddc', 'patchBuffer', [a:bufnr, a:dict], {-> v:null}, {-> v:null})
+  endif
+endfunction
+
+function! ddc#custom#patch_global(key_or_dict, ...) abort
+  let dict = s:normalize_key_or_dict({}, a:key_or_dict, get(a:000, 0, ''))
+  call s:patch_global(dict)
+endfunction
+
+function! ddc#custom#patch_filetype(ft, key_or_dict, ...) abort
+  let dict = s:normalize_key_or_dict({}, a:key_or_dict, get(a:000, 0, ''))
+  call s:patch_filetype(a:ft, dict)
+endfunction
+
+function! ddc#custom#patch_local(bufnr, key_or_dict, ...) abort
+  let dict = s:normalize_key_or_dict({}, a:key_or_dict, get(a:000, 0, ''))
+  let bufnr = bufnr('%')
+  call s:patch_buffer(bufnr, dict)
+endfunction
+
+" This should be called manually, so wait until DDCReady by the user himself.
+function! ddc#custom#get_global() abort
+  return denops#request('ddc', 'getGlobal', [])
+endfunction
+
+function! ddc#custom#get_filetype() abort
+  return denops#request('ddc', 'getFiletype', [])
+endfunction
+
+function! ddc#custom#get_buffer() abort
+  return denops#request('ddc', 'getBuffer', [])
+endfunction
+
+function! s:normalize_key_or_dict(base, key_or_dict, value) abort
+  if type(a:key_or_dict) == v:t_dict
+    call extend(a:base, a:key_or_dict)
+  else
+    let a:base[a:key_or_dict] = a:value
+  endif
+  return a:base
 endfunction

--- a/autoload/ddc/custom.vim
+++ b/autoload/ddc/custom.vim
@@ -41,17 +41,20 @@ function! s:patch_buffer(bufnr, dict) abort
 endfunction
 
 function! ddc#custom#patch_global(key_or_dict, ...) abort
-  let dict = s:normalize_key_or_dict({}, a:key_or_dict, get(a:000, 0, ''))
+  let dict = s:normalize_key_or_dict(a:key_or_dict, get(a:000, 0, ''))
   call s:patch_global(dict)
 endfunction
 
 function! ddc#custom#patch_filetype(ft, key_or_dict, ...) abort
-  let dict = s:normalize_key_or_dict({}, a:key_or_dict, get(a:000, 0, ''))
-  call s:patch_filetype(a:ft, dict)
+  let filetypes = s:normalize_string_or_list(a:ft)
+  let dict = s:normalize_key_or_dict(a:key_or_dict, get(a:000, 0, ''))
+  for filetype in filetypes
+    call s:patch_filetype(filetype, dict)
+  endfor
 endfunction
 
 function! ddc#custom#patch_local(bufnr, key_or_dict, ...) abort
-  let dict = s:normalize_key_or_dict({}, a:key_or_dict, get(a:000, 0, ''))
+  let dict = s:normalize_key_or_dict(a:key_or_dict, get(a:000, 0, ''))
   let bufnr = bufnr('%')
   call s:patch_buffer(bufnr, dict)
 endfunction
@@ -69,11 +72,22 @@ function! ddc#custom#get_buffer() abort
   return denops#request('ddc', 'getBuffer', [])
 endfunction
 
-function! s:normalize_key_or_dict(base, key_or_dict, value) abort
+function! s:normalize_key_or_dict(key_or_dict, value) abort
   if type(a:key_or_dict) == v:t_dict
-    call extend(a:base, a:key_or_dict)
-  else
-    let a:base[a:key_or_dict] = a:value
+    return a:key_or_dict
+  elseif type(a:key_or_dict) == v:t_string
+    let base = {}
+    let base[a:key_or_dict] = a:value
+    return base
   endif
-  return a:base
+  return {}
+endfunction
+
+function! s:normalize_string_or_list(string_or_list) abort
+  if type(a:string_or_list) == v:t_list
+    return a:string_or_list
+  elseif type(a:string_or_list) == v:t_string
+    return [a:string_or_list]
+  endif
+  return []
 endfunction

--- a/autoload/ddc/custom.vim
+++ b/autoload/ddc/custom.vim
@@ -53,10 +53,10 @@ function! ddc#custom#patch_filetype(ft, key_or_dict, ...) abort
   endfor
 endfunction
 
-function! ddc#custom#patch_local(bufnr, key_or_dict, ...) abort
+function! ddc#custom#patch_buffer(key_or_dict, ...) abort
   let dict = s:normalize_key_or_dict(a:key_or_dict, get(a:000, 0, ''))
-  let bufnr = bufnr('%')
-  call s:patch_buffer(bufnr, dict)
+  let n = bufnr('%')
+  call s:patch_buffer(n, dict)
 endfunction
 
 " This should be called manually, so wait until DDCReady by the user himself.

--- a/autoload/ddc/custom.vim
+++ b/autoload/ddc/custom.vim
@@ -12,7 +12,7 @@ function! s:patch_global(dict) abort
           \ )
   else
     call denops#request_async(
-    \ 'ddc', 'patchGlobal', [a:dict], {-> v:null}, {-> v:null})
+          \ 'ddc', 'patchGlobal', [a:dict], {-> v:null}, {-> v:null})
   endif
 endfunction
 
@@ -24,7 +24,7 @@ function! s:patch_filetype(ft, dict) abort
           \ )
   else
     call denops#request_async(
-    \ 'ddc', 'patchFiletype', [a:ft, a:dict], {-> v:null}, {-> v:null})
+          \ 'ddc', 'patchFiletype', [a:ft, a:dict], {-> v:null}, {-> v:null})
   endif
 endfunction
 
@@ -36,7 +36,7 @@ function! s:patch_buffer(bufnr, dict) abort
           \ )
   else
     call denops#request_async(
-    \ 'ddc', 'patchBuffer', [a:bufnr, a:dict], {-> v:null}, {-> v:null})
+          \ 'ddc', 'patchBuffer', [a:bufnr, a:dict], {-> v:null}, {-> v:null})
   endif
 endfunction
 

--- a/denops/ddc/app.ts
+++ b/denops/ddc/app.ts
@@ -41,6 +41,9 @@ export async function main(denops: Denops) {
       contextBuilder.patchBuffer(bufnr, options);
       return Promise.resolve();
     },
+    async _cacheWorld(arg1: unknown): Promise<unknown> {
+      return await contextBuilder.cacheWorld(denops, arg1 as string);
+    },
     getGlobal(): Promise<Partial<DdcOptions>> {
       return Promise.resolve(contextBuilder.getGlobal());
     },

--- a/denops/ddc/app.ts
+++ b/denops/ddc/app.ts
@@ -51,7 +51,7 @@ export async function main(denops: Denops) {
       return Promise.resolve(contextBuilder.getFiletype());
     },
     async _cacheWorld(arg1: unknown): Promise<unknown> {
-      return await contextBuilder.cacheWorld(denops, arg1 as string);
+      return await contextBuilder._cacheWorld(denops, arg1 as string);
     },
     async onEvent(arg1: unknown): Promise<void> {
       const event = arg1 as string;

--- a/denops/ddc/app.ts
+++ b/denops/ddc/app.ts
@@ -1,6 +1,7 @@
 import { autocmd, Denops, ensureObject, vars } from "./deps.ts";
 import { Ddc } from "./ddc.ts";
 import { ContextBuilder } from "./context.ts";
+import { DdcOptions } from "./types.ts";
 
 type RegisterArg = {
   path: string;
@@ -20,25 +21,34 @@ export async function main(denops: Denops) {
       const arg = arg1 as RegisterArg;
       await ddc.registerSource(arg.path, arg.name);
     },
-    customizeGlobal(arg1: unknown): Promise<void> {
+    patchGlobal(arg1: unknown): Promise<void> {
       ensureObject(arg1);
       const options = arg1 as Record<string, unknown>;
-      contextBuilder.customizeGlobal(options);
+      contextBuilder.patchGlobal(options);
       return Promise.resolve();
     },
-    customizeFiletype(arg1: unknown, arg2: unknown): Promise<void> {
+    patchFiletype(arg1: unknown, arg2: unknown): Promise<void> {
       const filetype = arg1 as string;
       ensureObject(arg2);
       const options = arg2 as Record<string, unknown>;
-      contextBuilder.customizeFiletype(filetype, options);
+      contextBuilder.patchFiletype(filetype, options);
       return Promise.resolve();
     },
-    customizeBuffer(arg1: unknown, arg2: unknown): Promise<void> {
+    patchBuffer(arg1: unknown, arg2: unknown): Promise<void> {
       const bufnr = arg1 as number;
       ensureObject(arg2);
       const options = arg2 as Record<string, unknown>;
-      contextBuilder.customizeBuffer(bufnr, options);
+      contextBuilder.patchBuffer(bufnr, options);
       return Promise.resolve();
+    },
+    getGlobal(): Promise<Partial<DdcOptions>> {
+      return Promise.resolve(contextBuilder.getGlobal());
+    },
+    getFiletype(): Promise<Record<string, Partial<DdcOptions>>> {
+      return Promise.resolve(contextBuilder.getFiletype());
+    },
+    getBuffer(): Promise<Record<number, Partial<DdcOptions>>> {
+      return Promise.resolve(contextBuilder.getFiletype());
     },
     async onEvent(arg1: unknown): Promise<void> {
       const event = arg1 as string;

--- a/denops/ddc/app.ts
+++ b/denops/ddc/app.ts
@@ -1,6 +1,6 @@
-import { autocmd, Denops, vars } from "./deps.ts";
+import { autocmd, Denops, ensureObject, vars } from "./deps.ts";
 import { Ddc } from "./ddc.ts";
-import { Context, Custom, defaultDdcOptions } from "./types.ts";
+import { ContextBuilder } from "./context.ts";
 
 type RegisterArg = {
   path: string;
@@ -9,84 +9,53 @@ type RegisterArg = {
 
 export async function main(denops: Denops) {
   const ddc: Ddc = new Ddc();
-  let lastInput = "";
+  const contextBuilder = new ContextBuilder();
 
   denops.dispatcher = {
     async registerFilter(arg1: unknown): Promise<void> {
       const arg = arg1 as RegisterArg;
-      const filter = await import(arg.path);
-      const name = arg.name;
-
-      ddc.filters[name] = new filter.Filter();
-      ddc.filters[name].name = name;
+      await ddc.registerFilter(arg.path, arg.name);
     },
     async registerSource(arg1: unknown): Promise<void> {
       const arg = arg1 as RegisterArg;
-      const source = await import(arg.path);
-      const name = arg.name;
-
-      const custom = await denops.call("ddc#custom#_get") as Custom;
-      const currentOptions = Object.assign(
-        custom.source._,
-        name in custom.source ? custom.source[name] : {},
-      );
-
-      const newSource = new source.Source();
-      newSource.name = name;
-      newSource.options.mark = name;
-      newSource.options = Object.assign(
-        newSource.options,
-        currentOptions,
-      );
-
-      ddc.sources[name] = newSource;
+      await ddc.registerSource(arg.path, arg.name);
     },
-    async start(arg: unknown): Promise<void> {
-      const event = arg as string;
-      const input = await denops.call("ddc#get_input", "") as string;
-      const completedItem = await vars.v.get(
-        denops,
-        "completed_item",
-      ) as Record<string, unknown>;
-
-      if (
-        input == lastInput ||
-        (event == "TextChangedP" && Object.keys(completedItem).length != 0)
-      ) {
-        return;
-      }
-
-      // Skip for iminsert
-      const iminsert = await denops.call("getbufvar", "%", "&iminsert");
-      if (iminsert == 1) {
-        return;
-      }
-
-      lastInput = input;
-
-      const custom = await denops.call("ddc#custom#_get") as Custom;
-      const userOptions = custom.option;
-      const context: Context = {
-        input: input,
-        options: Object.assign(
-          defaultDdcOptions,
-          userOptions,
-        ),
-      };
-      const candidates = await ddc.gatherCandidates(
-        denops,
-        context,
-      );
-
+    customizeGlobal(arg1: unknown): Promise<void> {
+      ensureObject(arg1);
+      const options = arg1 as Record<string, unknown>;
+      contextBuilder.customizeGlobal(options);
+      return Promise.resolve();
+    },
+    customizeFiletype(arg1: unknown, arg2: unknown): Promise<void> {
+      const filetype = arg1 as string;
+      ensureObject(arg2);
+      const options = arg2 as Record<string, unknown>;
+      contextBuilder.customizeFiletype(filetype, options);
+      return Promise.resolve();
+    },
+    customizeBuffer(arg1: unknown, arg2: unknown): Promise<void> {
+      const bufnr = arg1 as number;
+      ensureObject(arg2);
+      const options = arg2 as Record<string, unknown>;
+      contextBuilder.customizeBuffer(bufnr, options);
+      return Promise.resolve();
+    },
+    async onEvent(arg1: unknown): Promise<void> {
+      const event = arg1 as string;
+      const maybe = await contextBuilder.createContext(denops, event);
+      if (!maybe) return;
+      const [context, options] = maybe;
+      const candidates = await ddc.gatherCandidates(denops, context, options);
       const matchPos = context.input.search(/\w*$/);
+      const completePos = matchPos != null ? matchPos : -1;
 
-      await vars.g.set(
-        denops,
-        "ddc#_complete_pos",
-        matchPos != null ? matchPos : -1,
-      );
-      await vars.g.set(denops, "ddc#_candidates", candidates);
-      await denops.call("ddc#complete");
+      await (async function write() {
+        await Promise.all([
+          vars.g.set(denops, "ddc#_complete_pos", completePos),
+          vars.g.set(denops, "ddc#_candidates", candidates),
+        ]);
+        await denops.call("ddc#complete");
+      })();
     },
   };
 
@@ -95,17 +64,17 @@ export async function main(denops: Denops) {
     helper.define(
       "InsertEnter",
       "*",
-      `call denops#notify('${denops.name}', 'start', ["InsertEnter"])`,
+      `call denops#notify('${denops.name}', 'onEvent', ["InsertEnter"])`,
     );
     helper.define(
       "TextChangedI",
       "*",
-      `call denops#notify('${denops.name}', 'start', ["TextChangedI"])`,
+      `call denops#notify('${denops.name}', 'onEvent', ["TextChangedI"])`,
     );
     helper.define(
       "TextChangedP",
       "*",
-      `call denops#notify('${denops.name}', 'start', ["TextChangedP"])`,
+      `call denops#notify('${denops.name}', 'onEvent', ["TextChangedP"])`,
     );
   });
 

--- a/denops/ddc/app.ts
+++ b/denops/ddc/app.ts
@@ -41,9 +41,6 @@ export async function main(denops: Denops) {
       contextBuilder.patchBuffer(bufnr, options);
       return Promise.resolve();
     },
-    async _cacheWorld(arg1: unknown): Promise<unknown> {
-      return await contextBuilder.cacheWorld(denops, arg1 as string);
-    },
     getGlobal(): Promise<Partial<DdcOptions>> {
       return Promise.resolve(contextBuilder.getGlobal());
     },
@@ -52,6 +49,9 @@ export async function main(denops: Denops) {
     },
     getBuffer(): Promise<Record<number, Partial<DdcOptions>>> {
       return Promise.resolve(contextBuilder.getFiletype());
+    },
+    async _cacheWorld(arg1: unknown): Promise<unknown> {
+      return await contextBuilder.cacheWorld(denops, arg1 as string);
     },
     async onEvent(arg1: unknown): Promise<void> {
       const event = arg1 as string;

--- a/denops/ddc/base/filter.ts
+++ b/denops/ddc/base/filter.ts
@@ -1,12 +1,30 @@
-import { Candidate, Context } from "../types.ts";
+import { Candidate, Context, FilterOptions } from "../types.ts";
 import { Denops } from "../deps.ts";
 
 export abstract class BaseFilter {
-  name = "";
+  abstract name: string;
 
   abstract filter(
     denops: Denops,
     context: Context,
+    options: FilterOptions,
+    params: Record<string, unknown>,
     candidates: Candidate[],
   ): Promise<Candidate[]>;
+
+  options(): Partial<FilterOptions> {
+    return {};
+  }
+
+  abstract params(): Record<string, unknown>;
+}
+
+export function defaultFilterOptions(): FilterOptions {
+  return {
+    placeholder: undefined,
+  };
+}
+
+export function defaultFilterParams(): Record<string, unknown> {
+  return {};
 }

--- a/denops/ddc/base/filter.ts
+++ b/denops/ddc/base/filter.ts
@@ -2,8 +2,7 @@ import { Candidate, Context, FilterOptions } from "../types.ts";
 import { Denops } from "../deps.ts";
 
 export abstract class BaseFilter {
-  abstract name: string;
-
+  name = "";
   abstract filter(
     denops: Denops,
     context: Context,
@@ -11,10 +10,6 @@ export abstract class BaseFilter {
     params: Record<string, unknown>,
     candidates: Candidate[],
   ): Promise<Candidate[]>;
-
-  options(): Partial<FilterOptions> {
-    return {};
-  }
 
   abstract params(): Record<string, unknown>;
 }

--- a/denops/ddc/base/source.ts
+++ b/denops/ddc/base/source.ts
@@ -1,10 +1,34 @@
-import { Candidate, defaultSourceOptions } from "../types.ts";
+import { Candidate, Context, SourceOptions } from "../types.ts";
 import { Denops } from "../deps.ts";
 
 export abstract class BaseSource {
-  name = "";
-  options = defaultSourceOptions;
-  vars = {};
+  abstract name: string;
 
-  abstract gatherCandidates(denops: Denops): Promise<Candidate[]>;
+  abstract gatherCandidates(
+    denops: Denops,
+    context: Context,
+    options: SourceOptions,
+    params: Record<string, unknown>,
+  ): Promise<Candidate[]>;
+
+  options(): Partial<SourceOptions> {
+    return {
+      mark: this.name,
+    };
+  }
+
+  abstract params(): Record<string, unknown>;
+}
+
+export function defaultSourceOptions(): SourceOptions {
+  return {
+    mark: "",
+    matchers: [],
+    sorters: [],
+    converters: [],
+  };
+}
+
+export function defaultSourceParams(): Record<string, unknown> {
+  return {};
 }

--- a/denops/ddc/base/source.ts
+++ b/denops/ddc/base/source.ts
@@ -2,20 +2,13 @@ import { Candidate, Context, SourceOptions } from "../types.ts";
 import { Denops } from "../deps.ts";
 
 export abstract class BaseSource {
-  abstract name: string;
-
+  name = "";
   abstract gatherCandidates(
     denops: Denops,
     context: Context,
     options: SourceOptions,
     params: Record<string, unknown>,
   ): Promise<Candidate[]>;
-
-  options(): Partial<SourceOptions> {
-    return {
-      mark: this.name,
-    };
-  }
 
   abstract params(): Record<string, unknown>;
 }

--- a/denops/ddc/context.ts
+++ b/denops/ddc/context.ts
@@ -1,0 +1,261 @@
+import { Denops, vars } from "./deps.ts";
+import { Context, DdcOptions } from "./types.ts";
+import { reduce } from "https://deno.land/x/itertools@v0.1.2/mod.ts";
+
+// where
+// T: Object
+// partialMerge: PartialMerge
+// merge: Merge
+// partialMerge(partialMerge(a, b), c) == partialMerge(a, partialMerge(b, c))
+type PartialMerge<T> = (a: Partial<T>, b: Partial<T>) => Partial<T>;
+type Merge<T> = (a: T, b: Partial<T>) => T;
+type Default<T> = () => T;
+
+export function partialOverwrite<T>(a: Partial<T>, b: Partial<T>): Partial<T> {
+  return { ...a, ...b };
+}
+
+export function overwrite<T>(a: T, b: Partial<T>): T {
+  return { ...a, ...b };
+}
+
+export const partialMergeSourceOptions = partialOverwrite;
+export const partialMergeSourceParams = partialOverwrite;
+export const partialMergeFilterOptions = partialOverwrite;
+export const partialMergeFilterParams = partialOverwrite;
+export const mergeSourceOptions = overwrite;
+export const mergeSourceParams = overwrite;
+export const mergeFilterOptions = overwrite;
+export const mergeFilterParams = overwrite;
+
+export function foldMerge<T>(
+  merge: Merge<T>,
+  def: Default<T>,
+  partials: (null | undefined | Partial<T>)[],
+): T {
+  return reduce(
+    partials.map((x) => x || {}),
+    merge,
+    def(),
+  );
+}
+
+export function defaultDdcOptions(): DdcOptions {
+  return {
+    sources: [],
+    defaultMatchers: [],
+    defaultSorters: [],
+    defaultConverters: [],
+    sourceOptions: {},
+    sourceParams: {},
+    filterOptions: {},
+    filterParams: {},
+  };
+}
+
+function mergeEachKeys<T>(
+  merge: PartialMerge<T>,
+  a: Record<string, Partial<T>>,
+  b: Record<string, Partial<T>>,
+): Record<string, Partial<T>> {
+  const ret: Record<string, Partial<T>> = {};
+  for (const key in a) {
+    ret[key] = a[key];
+  }
+  for (const key in b) {
+    if (key in ret) {
+      ret[key] = merge(ret[key], b[key]);
+    } else {
+      ret[key] = b[key];
+    }
+  }
+  return ret;
+}
+
+function partialMergeDdcOptions(
+  a: Partial<DdcOptions>,
+  b: Partial<DdcOptions>,
+): Partial<DdcOptions> {
+  const overwritten: Partial<DdcOptions> = { ...a, ...b };
+  const ret: Partial<DdcOptions> = {};
+  if ("sources" in overwritten) ret.sources = overwritten.sources;
+  if ("defaultMatchers" in overwritten) {
+    ret.defaultMatchers = overwritten.defaultMatchers;
+  }
+  if ("defaultSorters" in overwritten) {
+    ret.defaultSorters = overwritten.defaultSorters;
+  }
+  if ("defaultConverters" in overwritten) {
+    ret.defaultConverters = overwritten.defaultConverters;
+  }
+  ret.sourceOptions = mergeEachKeys(
+    mergeSourceOptions,
+    a.sourceOptions || {},
+    b.sourceOptions || {},
+  );
+  ret.filterOptions = mergeEachKeys(
+    mergeFilterOptions,
+    a.filterOptions || {},
+    b.filterOptions || {},
+  );
+  ret.sourceParams = mergeEachKeys(
+    mergeSourceParams,
+    a.sourceParams || {},
+    b.sourceParams || {},
+  );
+  ret.filterParams = mergeEachKeys(
+    mergeFilterParams,
+    a.filterParams || {},
+    b.filterParams || {},
+  );
+  return ret;
+}
+
+export function mergeDdcOptions(
+  a: DdcOptions,
+  b: Partial<DdcOptions>,
+): DdcOptions {
+  const overwritten: DdcOptions = { ...a, ...b };
+  return {
+    sources: overwritten.sources,
+    defaultMatchers: overwritten.defaultMatchers,
+    defaultSorters: overwritten.defaultSorters,
+    defaultConverters: overwritten.defaultConverters,
+    sourceOptions: mergeEachKeys(
+      mergeSourceOptions,
+      a.sourceOptions,
+      b.sourceOptions || {},
+    ),
+    filterOptions: mergeEachKeys(
+      mergeFilterOptions,
+      a.filterOptions,
+      b.filterOptions || {},
+    ),
+    sourceParams: mergeEachKeys(
+      mergeSourceParams,
+      a.sourceParams,
+      b.sourceParams || {},
+    ),
+    filterParams: mergeEachKeys(
+      mergeFilterParams,
+      a.filterParams,
+      b.filterParams || {},
+    ),
+  };
+}
+
+// Customization by end users
+class Custom {
+  global: Partial<DdcOptions> = {};
+  filetype: Record<string, Partial<DdcOptions>> = {};
+  buffer: Record<number, Partial<DdcOptions>> = {};
+
+  get(ft: string, bufnr: number): Partial<DdcOptions> {
+    const filetype = this.filetype[ft] || {};
+    const buffer = this.buffer[bufnr] || {};
+    let ret = this.global;
+    ret = partialMergeDdcOptions(ret, filetype);
+    ret = partialMergeDdcOptions(ret, buffer);
+    return ret;
+  }
+
+  set_global(options: Partial<DdcOptions>) {
+    this.global = options;
+  }
+  set_filetype(ft: string, options: Partial<DdcOptions>) {
+    this.filetype[ft] = options;
+  }
+  set_buffer(bufnr: number, options: Partial<DdcOptions>) {
+    this.buffer[bufnr] = options;
+  }
+}
+
+// Caches the state of buffers, etc. immediately after an event occurs.
+interface World {
+  bufnr: number;
+  filetype: string;
+  event: string;
+  mode: string;
+  input: string;
+  changedByCompletion: boolean;
+  isLmap: boolean;
+}
+
+// Fetchs current state
+async function cacheWorld(denops: Denops, event: string): Promise<World> {
+  const changedByCompletion: Promise<boolean> = (async () => {
+    const completedItem =
+      (await vars.v.get(denops, "completed_item")) as Record<string, unknown>;
+    return event == "TextChangedP" && Object.keys(completedItem).length != 0;
+  })();
+  const isLmap: Promise<boolean> = (async () => {
+    const iminsert =
+      (await denops.call("getbufvar", "%", "&iminsert")) as number;
+    return iminsert == 1;
+  })();
+  const mode: string = event == "InsertEnter"
+    ? "i"
+    : (await denops.call("mode")) as string;
+  const input: Promise<string> = (async () => {
+    return (await denops.call("ddc#get_input", mode)) as string;
+  })();
+  const bufnr: Promise<number> = (async () => {
+    return (await denops.call("bufnr")) as number;
+  })();
+  const filetype: Promise<string> = (async () => {
+    return (await denops.call("getbufvar", "%", "&filetype")) as string;
+  })();
+  return {
+    bufnr: await bufnr,
+    filetype: await filetype,
+    event: event,
+    mode: mode,
+    input: await input,
+    changedByCompletion: await changedByCompletion,
+    isLmap: await isLmap,
+  };
+}
+
+export class ContextBuilder {
+  lastWorld: World;
+  custom: Custom = new Custom();
+
+  constructor() {
+    this.lastWorld = {
+      bufnr: 0,
+      filetype: "",
+      event: "",
+      mode: "",
+      input: "",
+      changedByCompletion: false,
+      isLmap: false,
+    };
+  }
+
+  async createContext(
+    denops: Denops,
+    event: string,
+  ): Promise<null | [Context, Partial<DdcOptions>]> {
+    const world = await cacheWorld(denops, event);
+    if (this.lastWorld == world) return null;
+    this.lastWorld = world;
+    if (world.isLmap || world.changedByCompletion) {
+      return null;
+    }
+    const userOptions = this.custom.get(world.filetype, world.bufnr);
+    const context = {
+      input: world.input,
+    };
+    return [context, userOptions];
+  }
+
+  customizeGlobal(options: Partial<DdcOptions>) {
+    this.custom.set_global(options);
+  }
+  customizeFiletype(ft: string, options: Partial<DdcOptions>) {
+    this.custom.set_filetype(ft, options);
+  }
+  customizeBuffer(bufnr: number, options: Partial<DdcOptions>) {
+    this.custom.set_buffer(bufnr, options);
+  }
+}

--- a/denops/ddc/context.ts
+++ b/denops/ddc/context.ts
@@ -159,14 +159,23 @@ class Custom {
     return ret;
   }
 
-  set_global(options: Partial<DdcOptions>) {
+  setGlobal(options: Partial<DdcOptions>) {
     this.global = options;
   }
-  set_filetype(ft: string, options: Partial<DdcOptions>) {
+  setFiletype(ft: string, options: Partial<DdcOptions>) {
     this.filetype[ft] = options;
   }
-  set_buffer(bufnr: number, options: Partial<DdcOptions>) {
+  setBuffer(bufnr: number, options: Partial<DdcOptions>) {
     this.buffer[bufnr] = options;
+  }
+  patchGlobal(options: Partial<DdcOptions>) {
+    Object.assign(this.global, options);
+  }
+  patchFiletype(ft: string, options: Partial<DdcOptions>) {
+    Object.assign(this.filetype[ft] || {}, options);
+  }
+  patchBuffer(bufnr: number, options: Partial<DdcOptions>) {
+    Object.assign(this.buffer[bufnr] || {}, options);
   }
 }
 
@@ -249,13 +258,23 @@ export class ContextBuilder {
     return [context, userOptions];
   }
 
-  customizeGlobal(options: Partial<DdcOptions>) {
-    this.custom.set_global(options);
+  getGlobal(): Partial<DdcOptions> {
+    return this.custom.global;
   }
-  customizeFiletype(ft: string, options: Partial<DdcOptions>) {
-    this.custom.set_filetype(ft, options);
+  getFiletype(): Record<string, Partial<DdcOptions>> {
+    return this.custom.filetype;
   }
-  customizeBuffer(bufnr: number, options: Partial<DdcOptions>) {
-    this.custom.set_buffer(bufnr, options);
+  getBuffer(): Record<number, Partial<DdcOptions>> {
+    return this.custom.buffer;
+  }
+
+  patchGlobal(options: Partial<DdcOptions>) {
+    this.custom.patchGlobal(options);
+  }
+  patchFiletype(ft: string, options: Partial<DdcOptions>) {
+    this.custom.patchFiletype(ft, options);
+  }
+  patchBuffer(bufnr: number, options: Partial<DdcOptions>) {
+    this.custom.patchBuffer(bufnr, options);
   }
 }

--- a/denops/ddc/context.ts
+++ b/denops/ddc/context.ts
@@ -1,11 +1,10 @@
 import { assertEquals, Denops, vars } from "./deps.ts";
-import { Context, DdcOptions } from "./types.ts";
+import { Context, DdcOptions, FilterOptions, SourceOptions } from "./types.ts";
 import { reduce } from "https://deno.land/x/itertools@v0.1.2/mod.ts";
 
 // where
 // T: Object
 // partialMerge: PartialMerge
-// merge: Merge
 // partialMerge(partialMerge(a, b), c) == partialMerge(a, partialMerge(b, c))
 type PartialMerge<T> = (a: Partial<T>, b: Partial<T>) => Partial<T>;
 type Merge<T> = (a: T, b: Partial<T>) => T;
@@ -15,13 +14,13 @@ function partialOverwrite<T>(a: Partial<T>, b: Partial<T>): Partial<T> {
   return { ...a, ...b };
 }
 
-export function overwrite<T>(a: T, b: Partial<T>): T {
+function overwrite<T>(a: T, b: Partial<T>): T {
   return { ...a, ...b };
 }
-export const mergeSourceOptions = overwrite;
-export const mergeSourceParams = overwrite;
-export const mergeFilterOptions = overwrite;
-export const mergeFilterParams = overwrite;
+export const mergeSourceOptions: Merge<SourceOptions> = overwrite;
+export const mergeFilterOptions: Merge<FilterOptions> = overwrite;
+export const mergeSourceParams: Merge<Record<string, unknown>> = overwrite;
+export const mergeFilterParams: Merge<Record<string, unknown>> = overwrite;
 
 export function foldMerge<T>(
   merge: Merge<T>,
@@ -298,6 +297,21 @@ Deno.test("patchDdcOptions", () => {
           foo: "bar",
         },
       },
+    })
+    .patchFiletype("cpp", {
+      filterParams: {
+        "hoge": {
+          foo: "bar",
+        },
+      },
+    })
+    .patchFiletype("cpp", {
+      filterParams: {
+        "hoge": {
+          foo: "baz",
+          alice: "bob",
+        },
+      },
     });
   assertEquals(custom.global, {
     sources: ["around", "baz"],
@@ -315,6 +329,14 @@ Deno.test("patchDdcOptions", () => {
       filterParams: {
         "hoge": {
           foo: "bar",
+        },
+      },
+    },
+    cpp: {
+      filterParams: {
+        "hoge": {
+          foo: "baz",
+          alice: "bob",
         },
       },
     },

--- a/denops/ddc/context.ts
+++ b/denops/ddc/context.ts
@@ -39,9 +39,6 @@ export function foldMerge<T>(
 export function defaultDdcOptions(): DdcOptions {
   return {
     sources: [],
-    defaultMatchers: [],
-    defaultSorters: [],
-    defaultConverters: [],
     sourceOptions: {},
     sourceParams: {},
     filterOptions: {},
@@ -84,9 +81,6 @@ export function mergeDdcOptions(
   const partialMergeFilterParams = partialOverwrite;
   return {
     sources: overwritten.sources,
-    defaultMatchers: overwritten.defaultMatchers,
-    defaultSorters: overwritten.defaultSorters,
-    defaultConverters: overwritten.defaultConverters,
     sourceOptions: migrateEachKeys(
       partialMergeSourceOptions,
       a.sourceOptions,
@@ -352,10 +346,6 @@ Deno.test("mergeDdcOptions", () => {
   });
   custom.patchBuffer(2, {});
   assertEquals(custom.get("typescript", 1), {
-    defaultMatchers: [],
-    defaultSorters: [],
-    defaultConverters: [],
-
     sources: ["around", "foo"],
     sourceOptions: {},
     filterOptions: {},
@@ -374,10 +364,6 @@ Deno.test("mergeDdcOptions", () => {
     },
   });
   assertEquals(custom.get("typescript", 2), {
-    defaultMatchers: [],
-    defaultSorters: [],
-    defaultConverters: [],
-
     sources: [],
     sourceOptions: {},
     filterOptions: {},
@@ -393,10 +379,6 @@ Deno.test("mergeDdcOptions", () => {
     },
   });
   assertEquals(custom.get("cpp", 1), {
-    defaultMatchers: [],
-    defaultSorters: [],
-    defaultConverters: [],
-
     sources: ["around", "foo"],
     sourceOptions: {},
     filterOptions: {},

--- a/denops/ddc/context.ts
+++ b/denops/ddc/context.ts
@@ -169,8 +169,8 @@ class Custom {
   }
 }
 
-// Caches the state of buffers, etc. immediately after an event occurs.
-interface World {
+// Schema of the state of buffers, etc
+type World = {
   bufnr: number;
   filetype: string;
   event: string;
@@ -178,6 +178,18 @@ interface World {
   input: string;
   changedByCompletion: boolean;
   isLmap: boolean;
+};
+
+function initialWorld(): World {
+  return {
+    bufnr: 0,
+    filetype: "",
+    event: "",
+    mode: "",
+    input: "",
+    changedByCompletion: false,
+    isLmap: false,
+  };
 }
 
 // Fetchs current state
@@ -216,22 +228,11 @@ async function cacheWorld(denops: Denops, event: string): Promise<World> {
 }
 
 export class ContextBuilder {
-  lastWorld: World;
-  custom: Custom = new Custom();
+  private lastWorld: World = initialWorld();
+  private custom: Custom = new Custom();
 
-  constructor() {
-    this.lastWorld = {
-      bufnr: 0,
-      filetype: "",
-      event: "",
-      mode: "",
-      input: "",
-      changedByCompletion: false,
-      isLmap: false,
-    };
-  }
-
-  async cacheWorld(denops: Denops, event: string): Promise<World> {
+  // Re-export for denops.dispatcher
+  async _cacheWorld(denops: Denops, event: string): Promise<World> {
     return await cacheWorld(denops, event);
   }
 
@@ -239,7 +240,7 @@ export class ContextBuilder {
     denops: Denops,
     event: string,
   ): Promise<null | [Context, DdcOptions]> {
-    const world = await this.cacheWorld(denops, event);
+    const world = await this._cacheWorld(denops, event);
     if (this.lastWorld == world) return null;
     this.lastWorld = world;
     if (world.isLmap || world.changedByCompletion) {

--- a/denops/ddc/context.ts
+++ b/denops/ddc/context.ts
@@ -1,7 +1,6 @@
-import { Denops, vars } from "./deps.ts";
+import { assertEquals, Denops, vars } from "./deps.ts";
 import { Context, DdcOptions } from "./types.ts";
 import { reduce } from "https://deno.land/x/itertools@v0.1.2/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.98.0/testing/asserts.ts";
 
 // where
 // T: Object
@@ -144,23 +143,29 @@ class Custom {
     ]);
   }
 
-  setGlobal(options: Partial<DdcOptions>) {
+  setGlobal(options: Partial<DdcOptions>): Custom {
     this.global = options;
+    return this;
   }
-  setFiletype(ft: string, options: Partial<DdcOptions>) {
+  setFiletype(ft: string, options: Partial<DdcOptions>): Custom {
     this.filetype[ft] = options;
+    return this;
   }
-  setBuffer(bufnr: number, options: Partial<DdcOptions>) {
+  setBuffer(bufnr: number, options: Partial<DdcOptions>): Custom {
     this.buffer[bufnr] = options;
+    return this;
   }
-  patchGlobal(options: Partial<DdcOptions>) {
+  patchGlobal(options: Partial<DdcOptions>): Custom {
     this.global = patchDdcOptions(this.global, options);
+    return this;
   }
-  patchFiletype(ft: string, options: Partial<DdcOptions>) {
+  patchFiletype(ft: string, options: Partial<DdcOptions>): Custom {
     this.filetype[ft] = patchDdcOptions(this.filetype[ft] || {}, options);
+    return this;
   }
-  patchBuffer(bufnr: number, options: Partial<DdcOptions>) {
+  patchBuffer(bufnr: number, options: Partial<DdcOptions>): Custom {
     this.buffer[bufnr] = patchDdcOptions(this.buffer[bufnr] || {}, options);
+    return this;
   }
 }
 
@@ -269,23 +274,30 @@ export class ContextBuilder {
 }
 
 Deno.test("patchDdcOptions", () => {
-  const custom = new Custom();
-  custom.setGlobal({
-    sources: ["around"],
-    sourceParams: {
-      "around": {
-        maxSize: 300,
+  const custom = (new Custom())
+    .setGlobal({
+      sources: ["around"],
+      sourceParams: {
+        "around": {
+          maxSize: 300,
+        },
       },
-    },
-  });
-  custom.patchGlobal({
-    sources: ["around", "baz"],
-    sourceParams: {
-      "baz": {
-        foo: "bar",
+    })
+    .patchGlobal({
+      sources: ["around", "baz"],
+      sourceParams: {
+        "baz": {
+          foo: "bar",
+        },
       },
-    },
-  });
+    })
+    .patchFiletype("markdown", {
+      filterParams: {
+        "hoge": {
+          foo: "bar",
+        },
+      },
+    });
   assertEquals(custom.global, {
     sources: ["around", "baz"],
     sourceParams: {
@@ -293,13 +305,6 @@ Deno.test("patchDdcOptions", () => {
         maxSize: 300,
       },
       "baz": {
-        foo: "bar",
-      },
-    },
-  });
-  custom.patchFiletype("markdown", {
-    filterParams: {
-      "hoge": {
         foo: "bar",
       },
     },
@@ -316,35 +321,35 @@ Deno.test("patchDdcOptions", () => {
 });
 
 Deno.test("mergeDdcOptions", () => {
-  const custom = new Custom();
-  custom.setGlobal({
-    sources: ["around"],
-    sourceParams: {
-      "around": {
-        maxSize: 300,
+  const custom = (new Custom())
+    .setGlobal({
+      sources: ["around"],
+      sourceParams: {
+        "around": {
+          maxSize: 300,
+        },
       },
-    },
-  });
-  custom.setFiletype("typescript", {
-    sources: [],
-    filterParams: {
-      "matcher_head": {
-        foo: 2,
+    })
+    .setFiletype("typescript", {
+      sources: [],
+      filterParams: {
+        "matcher_head": {
+          foo: 2,
+        },
       },
-    },
-  });
-  custom.setBuffer(1, {
-    sources: ["around", "foo"],
-    filterParams: {
-      "matcher_head": {
-        foo: 3,
+    })
+    .setBuffer(1, {
+      sources: ["around", "foo"],
+      filterParams: {
+        "matcher_head": {
+          foo: 3,
+        },
+        "foo": {
+          max: 200,
+        },
       },
-      "foo": {
-        max: 200,
-      },
-    },
-  });
-  custom.patchBuffer(2, {});
+    })
+    .patchBuffer(2, {});
   assertEquals(custom.get("typescript", 1), {
     sources: ["around", "foo"],
     sourceOptions: {},

--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -125,27 +125,24 @@ export class Ddc {
     const sorters = foundFilters(filtersUsed.sorters);
     const converters = foundFilters(filtersUsed.converters);
 
-    const filterOptionsOf = (filter: BaseFilter) =>
+    const optionsOf = (filter: BaseFilter) =>
       mergeFilterOptions(defaultFilterOptions(), filterOptions[filter.name]);
-    const foldParamsOf = (filter: BaseFilter) =>
+    const paramsOf = (filter: BaseFilter) =>
       foldMerge(mergeFilterParams, defaultFilterParams, [
         filter.params(),
         filterParams[filter.name],
       ]);
 
     for (const matcher of matchers) {
-      const o = filterOptionsOf(matcher);
-      const p = foldParamsOf(matcher);
+      const [o, p] = [optionsOf(matcher), paramsOf(matcher)];
       cdd = await matcher.filter(denops, context, o, p, cdd);
     }
     for (const sorter of sorters) {
-      const o = filterOptionsOf(sorter);
-      const p = foldParamsOf(sorter);
+      const [o, p] = [optionsOf(sorter), paramsOf(sorter)];
       cdd = await sorter.filter(denops, context, o, p, cdd);
     }
     for (const converter of converters) {
-      const o = filterOptionsOf(converter);
-      const p = foldParamsOf(converter);
+      const [o, p] = [optionsOf(converter), paramsOf(converter)];
       cdd = await converter.filter(denops, context, o, p, cdd);
     }
     return cdd;

--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -1,12 +1,30 @@
 import {
-  BaseFilter,
-  BaseSource,
   Candidate,
   Context,
   DdcCandidate,
   DdcOptions,
-  defaultDdcOptions,
+  FilterOptions,
 } from "./types.ts";
+import {
+  defaultDdcOptions,
+  foldMerge,
+  mergeDdcOptions,
+  mergeFilterOptions,
+  mergeFilterParams,
+  mergeSourceOptions,
+  mergeSourceParams,
+  overwrite,
+} from "./context.ts";
+import {
+  BaseSource,
+  defaultSourceOptions,
+  defaultSourceParams,
+} from "./base/source.ts";
+import {
+  BaseFilter,
+  defaultFilterOptions,
+  defaultFilterParams,
+} from "./base/filter.ts";
 import { Denops } from "./deps.ts";
 
 function formatMenu(prefix: string, menu: string | undefined): string {
@@ -18,35 +36,87 @@ function formatMenu(prefix: string, menu: string | undefined): string {
     : `[${prefix}] ${menu}`;
 }
 
+interface FiltersUsed {
+  matchers: string[];
+  sorters: string[];
+  converters: string[];
+}
+
 export class Ddc {
   sources: Record<string, BaseSource> = {};
   filters: Record<string, BaseFilter> = {};
-  options: DdcOptions = defaultDdcOptions;
+
+  async registerFilter(path: string, name: string) {
+    const mod = await import(path);
+    const filter = new mod.Filter();
+    filter.name = name;
+    this.filters[filter.name] = filter;
+  }
+  async registerSource(path: string, name: string) {
+    const mod = await import(path);
+    const source = new mod.Source();
+    source.name = name;
+    this.sources[source.name] = source;
+  }
 
   async gatherCandidates(
     denops: Denops,
     context: Context,
+    userOptions: Partial<DdcOptions>,
   ): Promise<DdcCandidate[]> {
     let candidates: DdcCandidate[] = [];
-    const currentSources: string[] = "_" in context.options.sources
-      ? context.options.sources._
-      : [];
-    for (const key in currentSources) {
-      if (!(currentSources[key] in this.sources)) {
-        continue;
-      }
+    const options: DdcOptions = mergeDdcOptions(
+      defaultDdcOptions(),
+      userOptions,
+    );
+    const sources = options.sources.map((name) => this.sources[name])
+      .filter((x) => x);
 
-      const source = this.sources[currentSources[key]];
-      const sourceCandidates = await source.gatherCandidates(denops);
-
-      candidates = candidates.concat(
-        await this.filterCandidates(
-          denops,
-          context,
-          source,
-          sourceCandidates,
-        ),
+    for (const source of sources) {
+      const sourceOptions = foldMerge(
+        mergeSourceOptions,
+        defaultSourceOptions,
+        [source.options(), options.sourceOptions[source.name]],
       );
+      const sourceParams = foldMerge(mergeSourceParams, defaultSourceParams, [
+        source.params(),
+        options.sourceParams[source.name],
+      ]);
+      const sourceCandidates = await source.gatherCandidates(
+        denops,
+        context,
+        sourceOptions,
+        sourceParams,
+      );
+      const mergeFiltersUsed = overwrite;
+      const filtersUsed = foldMerge(
+        mergeFiltersUsed,
+        () => ({
+          matchers: options.defaultMatchers,
+          sorters: options.defaultSorters,
+          converters: options.defaultConverters,
+        }),
+        [source.options(), options.sourceOptions[source.name]],
+      );
+      const filterCandidates = await this.filterCandidates(
+        denops,
+        context,
+        filtersUsed,
+        options.filterOptions,
+        options.filterParams,
+        sourceCandidates,
+      );
+      const result: DdcCandidate[] = filterCandidates.map((c: Candidate) => (
+        {
+          ...c,
+          source: source.name,
+          icase: true,
+          equal: true,
+          menu: formatMenu(sourceOptions.mark, c.menu),
+        }
+      ));
+
+      candidates = candidates.concat(result);
     }
 
     return candidates;
@@ -54,48 +124,57 @@ export class Ddc {
   async filterCandidates(
     denops: Denops,
     context: Context,
-    source: BaseSource,
+    filtersUsed: FiltersUsed,
+    filterOptions: Record<string, Partial<FilterOptions>>,
+    filterParams: Record<string, Partial<Record<string, unknown>>>,
     cdd: Candidate[],
-  ): Promise<DdcCandidate[]> {
-    let cs = cdd;
+  ): Promise<Candidate[]> {
+    const foundFilters = (names: string[]) =>
+      names.map((name) => this.filters[name]).filter((x) => x);
+    const matchers = foundFilters(filtersUsed.matchers);
+    const sorters = foundFilters(filtersUsed.sorters);
+    const converters = foundFilters(filtersUsed.converters);
 
-    // Matchers
-    for (const key in this.filters) {
-      if (!(source.options.matchers.includes(key))) {
-        continue;
-      }
+    const foldOptions = (
+      partials: (null | undefined | Partial<FilterOptions>)[],
+    ) => foldMerge(mergeFilterOptions, defaultFilterOptions, partials);
+    const foldParams = (
+      partials: (null | undefined | Partial<Record<string, unknown>>)[],
+    ) => foldMerge(mergeFilterParams, defaultFilterParams, partials);
 
-      cs = await this.filters[key].filter(denops, context, cs);
+    for (const matcher of matchers) {
+      const o = foldOptions([
+        matcher.options(),
+        filterOptions[matcher.name],
+      ]);
+      const p = foldParams([
+        matcher.params(),
+        filterParams[matcher.name],
+      ]);
+      cdd = await matcher.filter(denops, context, o, p, cdd);
     }
-
-    // Sorters
-    for (const key in this.filters) {
-      if (!(source.options.sorters.includes(key))) {
-        continue;
-      }
-
-      cs = await this.filters[key].filter(denops, context, cs);
+    for (const sorter of sorters) {
+      const o = foldOptions([
+        sorter.options(),
+        filterOptions[sorter.name],
+      ]);
+      const p = foldParams([
+        sorter.params(),
+        filterParams[sorter.name],
+      ]);
+      cdd = await sorter.filter(denops, context, o, p, cdd);
     }
-
-    // Converters
-    for (const key in this.filters) {
-      if (!(source.options.converters.includes(key))) {
-        continue;
-      }
-
-      cs = await this.filters[key].filter(denops, context, cs);
+    for (const converter of converters) {
+      const o = foldOptions([
+        converter.options(),
+        filterOptions[converter.name],
+      ]);
+      const p = foldParams([
+        converter.params(),
+        filterParams[converter.name],
+      ]);
+      cdd = await converter.filter(denops, context, o, p, cdd);
     }
-
-    const candidates: DdcCandidate[] = [];
-    for (const candidate of cs) {
-      candidates.push(Object.assign(candidate, {
-        source: source.name,
-        icase: true,
-        equal: true,
-        menu: formatMenu(source.options.mark, candidate.menu),
-      }));
-    }
-
-    return candidates;
+    return cdd;
   }
 }

--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -35,11 +35,11 @@ function formatMenu(prefix: string, menu: string | undefined): string {
     : `[${prefix}] ${menu}`;
 }
 
-interface FiltersUsed {
+type FiltersUsed = {
   matchers: string[];
   sorters: string[];
   converters: string[];
-}
+};
 
 function sourceArgs(
   options: DdcOptions,
@@ -87,8 +87,8 @@ function filtersUsed(options: DdcOptions, sourceName: string): FiltersUsed {
 }
 
 export class Ddc {
-  sources: Record<string, BaseSource> = {};
-  filters: Record<string, BaseFilter> = {};
+  private sources: Record<string, BaseSource> = {};
+  private filters: Record<string, BaseFilter> = {};
 
   async registerFilter(path: string, name: string) {
     const mod = await import(path);
@@ -143,7 +143,8 @@ export class Ddc {
 
     return candidates;
   }
-  async filterCandidates(
+
+  private async filterCandidates(
     denops: Denops,
     context: Context,
     filtersUsed: FiltersUsed,

--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -83,11 +83,15 @@ export class Ddc {
         sourceParams,
       );
       const mergeFiltersUsed = overwrite;
-      const filtersUsed = foldMerge(mergeFiltersUsed, () => ({
-        matchers: options.defaultMatchers,
-        sorters: options.defaultSorters,
-        converters: options.defaultConverters,
-      }), [options.sourceOptions[source.name]]);
+      const defaultFiltersUsed = (): FiltersUsed => ({
+        matchers: [],
+        sorters: [],
+        converters: [],
+      });
+      const filtersUsed = foldMerge(mergeFiltersUsed, defaultFiltersUsed, [
+        options.sourceOptions["_"],
+        options.sourceOptions[source.name],
+      ]);
       const filterCandidates = await this.filterCandidates(
         denops,
         context,

--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -24,7 +24,7 @@ import {
   defaultFilterOptions,
   defaultFilterParams,
 } from "./base/filter.ts";
-import { Denops } from "./deps.ts";
+import { assertEquals, Denops } from "./deps.ts";
 
 function formatMenu(prefix: string, menu: string | undefined): string {
   menu = menu ? menu : "";
@@ -57,20 +57,6 @@ function sourceArgs(
   return [o, p];
 }
 
-function filtersUsed(options: DdcOptions, sourceName: string): FiltersUsed {
-  const mergeFiltersUsed = overwrite;
-  const defaultFiltersUsed = (): FiltersUsed => ({
-    matchers: [],
-    sorters: [],
-    converters: [],
-  });
-  const filtersUsed = foldMerge(mergeFiltersUsed, defaultFiltersUsed, [
-    options.sourceOptions["_"],
-    options.sourceOptions[sourceName],
-  ]);
-  return filtersUsed;
-}
-
 function filterArgs(
   filterOptions: Record<string, Partial<FilterOptions>>,
   filterParams: Record<string, Partial<Record<string, unknown>>>,
@@ -84,6 +70,20 @@ function filterArgs(
       filterParams[filter.name],
     ]);
   return [optionsOf(filter), paramsOf(filter)];
+}
+
+function filtersUsed(options: DdcOptions, sourceName: string): FiltersUsed {
+  const mergeFiltersUsed = overwrite;
+  const defaultFiltersUsed = (): FiltersUsed => ({
+    matchers: [],
+    sorters: [],
+    converters: [],
+  });
+  const filtersUsed = foldMerge(mergeFiltersUsed, defaultFiltersUsed, [
+    options.sourceOptions["_"],
+    options.sourceOptions[sourceName],
+  ]);
+  return filtersUsed;
 }
 
 export class Ddc {
@@ -172,3 +172,15 @@ export class Ddc {
     return cdd;
   }
 }
+
+Deno.test("sourceArgs", () => {
+  assertEquals(0, 1);
+});
+
+Deno.test("filterArgs", () => {
+  assertEquals(0, 1);
+});
+
+Deno.test("filtersUsed", () => {
+  assertEquals(0, 1);
+});

--- a/denops/ddc/deps.ts
+++ b/denops/ddc/deps.ts
@@ -3,3 +3,4 @@ export { execute } from "https://deno.land/x/denops_std@v1.0.0-beta.7/helper/mod
 export * as vars from "https://deno.land/x/denops_std@v1.0.0-beta.7/variable/mod.ts#^";
 export * as autocmd from "https://deno.land/x/denops_std@v1.0.0-beta.7/autocmd/mod.ts#^";
 export { ensureObject } from "https://deno.land/x/unknownutil@v0.1.1/mod.ts#^";
+export { assertEquals } from "https://deno.land/std@0.100.0/testing/asserts.ts";

--- a/denops/ddc/filters/matcher_head.ts
+++ b/denops/ddc/filters/matcher_head.ts
@@ -1,4 +1,4 @@
-import { BaseFilter, Candidate, Context } from "../types.ts";
+import { BaseFilter, Candidate, Context, FilterOptions } from "../types.ts";
 import { Denops } from "../deps.ts";
 import { assertEquals } from "https://deno.land/std@0.98.0/testing/asserts.ts";
 
@@ -8,9 +8,13 @@ function lastWord(input: string): string {
 }
 
 export class Filter extends BaseFilter {
+  name = "matcher_head";
+
   filter(
     _denops: Denops,
     context: Context,
+    _options: FilterOptions,
+    _params: Record<string, unknown>,
     candidates: Candidate[],
   ): Promise<Candidate[]> {
     const completeStr = lastWord(context.input);
@@ -18,6 +22,10 @@ export class Filter extends BaseFilter {
       (candidate) => candidate.word.startsWith(completeStr),
     );
     return Promise.resolve(filtered);
+  }
+
+  params(): Record<string, unknown> {
+    return {};
   }
 }
 

--- a/denops/ddc/filters/matcher_head.ts
+++ b/denops/ddc/filters/matcher_head.ts
@@ -8,8 +8,6 @@ function lastWord(input: string): string {
 }
 
 export class Filter extends BaseFilter {
-  name = "matcher_head";
-
   filter(
     _denops: Denops,
     context: Context,

--- a/denops/ddc/sources/around.ts
+++ b/denops/ddc/sources/around.ts
@@ -1,4 +1,4 @@
-import { BaseSource, Candidate } from "../types.ts";
+import { BaseSource, Candidate, Context, SourceOptions } from "../types.ts";
 import { Denops } from "../deps.ts";
 import { imap, range } from "https://deno.land/x/itertools@v0.1.2/mod.ts";
 import { assertEquals } from "https://deno.land/std@0.98.0/testing/asserts.ts";
@@ -19,10 +19,22 @@ function allWords(lines: string[]): string[] {
     .map((match) => match[0]);
 }
 
+interface Params {
+  maxSize: number;
+}
+
 export class Source extends BaseSource {
-  async gatherCandidates(denops: Denops): Promise<Candidate[]> {
+  name = "around";
+
+  async gatherCandidates(
+    denops: Denops,
+    _context: Context,
+    _options: SourceOptions,
+    params: Record<string, unknown>,
+  ): Promise<Candidate[]> {
     const pageSize = 500;
-    const maxSize = 200;
+    const p = params as unknown as Params;
+    const maxSize = p.maxSize;
     const currentLine = (await denops.call("line", ".")) as number;
     const minLines = Math.max(1, currentLine - maxSize);
     const maxLines = Math.min(
@@ -39,6 +51,13 @@ export class Source extends BaseSource {
 
     const candidates: Candidate[] = allWords(lines).map((word) => ({ word }));
     return candidates;
+  }
+
+  params(): Record<string, unknown> {
+    const params: Params = {
+      maxSize: 200,
+    };
+    return params as unknown as Record<string, unknown>;
   }
 }
 

--- a/denops/ddc/sources/around.ts
+++ b/denops/ddc/sources/around.ts
@@ -24,8 +24,6 @@ interface Params {
 }
 
 export class Source extends BaseSource {
-  name = "around";
-
   async gatherCandidates(
     denops: Denops,
     _context: Context,

--- a/denops/ddc/sources/around.ts
+++ b/denops/ddc/sources/around.ts
@@ -19,9 +19,9 @@ function allWords(lines: string[]): string[] {
     .map((match) => match[0]);
 }
 
-interface Params {
+type Params = {
   maxSize: number;
-}
+};
 
 export class Source extends BaseSource {
   async gatherCandidates(

--- a/denops/ddc/types.ts
+++ b/denops/ddc/types.ts
@@ -14,9 +14,6 @@ export interface Context {
 
 export interface DdcOptions {
   sources: SourceName[];
-  defaultMatchers: string[];
-  defaultSorters: string[];
-  defaultConverters: string[];
   sourceOptions: Record<SourceName, Partial<SourceOptions>>;
   sourceParams: Record<SourceName, Partial<Record<string, unknown>>>;
   filterOptions: Record<string, Partial<FilterOptions>>;

--- a/denops/ddc/types.ts
+++ b/denops/ddc/types.ts
@@ -8,6 +8,33 @@ export type Custom = {
   option: DdcOptions;
 };
 
+export interface Context {
+  input: string;
+}
+
+export interface DdcOptions {
+  sources: SourceName[];
+  defaultMatchers: string[];
+  defaultSorters: string[];
+  defaultConverters: string[];
+  sourceOptions: Record<SourceName, Partial<SourceOptions>>;
+  sourceParams: Record<SourceName, Partial<Record<string, unknown>>>;
+  filterOptions: Record<string, Partial<FilterOptions>>;
+  filterParams: Record<string, Partial<Record<string, unknown>>>;
+}
+
+export type SourceOptions = {
+  mark: string;
+  matchers: string[];
+  sorters: string[];
+  converters: string[];
+};
+
+export interface FilterOptions {
+  // TODO: add options and remove placeholder
+  placeholder: void;
+}
+
 export type Candidate = {
   word: string;
   abbr?: string;
@@ -23,31 +50,4 @@ export type DdcCandidate = Candidate & {
   icase: boolean;
   equal: boolean;
   source: SourceName;
-};
-
-export type DdcOptions = {
-  sources: Record<string, SourceName[]>;
-};
-
-export const defaultDdcOptions: DdcOptions = {
-  sources: {},
-};
-
-export type Context = {
-  input: string;
-  options: DdcOptions;
-};
-
-export type SourceOptions = {
-  mark: string;
-  matchers: string[];
-  sorters: string[];
-  converters: string[];
-};
-
-export const defaultSourceOptions: SourceOptions = {
-  mark: "",
-  matchers: [],
-  sorters: [],
-  converters: [],
 };

--- a/denops/ddc/types.ts
+++ b/denops/ddc/types.ts
@@ -8,17 +8,17 @@ export type Custom = {
   option: DdcOptions;
 };
 
-export interface Context {
+export type Context = {
   input: string;
-}
+};
 
-export interface DdcOptions {
+export type DdcOptions = {
   sources: SourceName[];
   sourceOptions: Record<SourceName, Partial<SourceOptions>>;
   sourceParams: Record<SourceName, Partial<Record<string, unknown>>>;
   filterOptions: Record<string, Partial<FilterOptions>>;
   filterParams: Record<string, Partial<Record<string, unknown>>>;
-}
+};
 
 export type SourceOptions = {
   mark: string;
@@ -27,10 +27,10 @@ export type SourceOptions = {
   converters: string[];
 };
 
-export interface FilterOptions {
+export type FilterOptions = {
   // TODO: add options and remove placeholder
   placeholder: void;
-}
+};
 
 export type Candidate = {
   word: string;

--- a/doc/ddc.txt
+++ b/doc/ddc.txt
@@ -15,12 +15,16 @@ Interface		|ddc-interface|
   Custom Functions	  |ddc-custom-functions|
 Examples		|ddc-examples|
 Sources			|ddc-sources|
-  Source options       |ddc-source-options|
+  Source option	         |ddc-source-options|
+  Source params	         |ddc-source-params|
+Filters			|ddc-filters|
+  Filter options          |ddc-filter-options|
+  Filter params	   |ddc-filter-params|
 Create source		|ddc-create-source|
   Source attributes       |ddc-source-attributes|
   Candidate attributes    |ddc-candidate-attributes|
 Create filter		|ddc-create-filter|
-FILTERS			|ddc-filters|
+  filter attributes       |ddc-filter-attributes|
 FAQ			|ddc-faq|
 Compatibility		|ddc-compatibility|
 
@@ -49,39 +53,81 @@ INTERFACE						*ddc-interface*
 ------------------------------------------------------------------------------
 OPTIONS	 						*ddc-options*
 
-Options can be toggled through the use of |ddc#custom#global()|.
+Options can be toggled through the use of |ddc#custom#patch_global()|.
 
 For example:
 
 >
     " Set a single option
-    call ddc#custom#global('auto_complete_delay', 200)
+    call ddc#custom#patch_global('auto_complete_delay', 200)
 
     " Pass a dictionary to set multiple options
-    call ddc#custom#global({
+    call ddc#custom#patch_global({
     \ 'auto_complete_delay': 200,
     \ 'smart_case': v:true,
     \ })
+
+    call ddc#custom#patch_filetype(['c', 'cpp'], 'sources', ['around'])
 <
 
 The set of available options follows.
 
 					*ddc-options-sources*
 sources
-		It is a dictionary to specify source names.  The key is
-		filetype and the value is a list of source names.  If the key
-		is "_", the value will be used for default filetypes.  For
-		example, you can load some sources in C++ filetype.  If the
-		value is [], it will not load any sources.
-		The order is used as source candidates rank.
+		It is a list of registered source names.  You have to select one or more
+		sources to use completion.
+		Candidates from sources with smaller indexes will have smaller indexes.
 
-		Default value: {}
+		Default value: []
 >
-		" Example:
-		call ddc#custom#global('sources', {
-		\ '_': ['around'],
-		\})
-<
+		" e.g.
+		call ddc#custom#patch_global('sources', ['around'])
+
+					*ddc-options-sourceOptions*
+sourceOptions
+		It is a dictionary that maps source names to its options.
+		The options with the name "_" is used as the options for all sources.
+		See also |ddc-source-options|.
+		Default value: {}
+
+		" e.g.
+		call ddc#custom#patch_global('sourceOptions', {
+		    \ '_': {'matchers': ['matcher_head']},
+		    \ 'around': {'mark': 'A'},
+		    \ })
+
+					*ddc-options-sourceParams*
+sourceParams
+		It is a dictionary that maps source names to its parameters.
+		See also |ddc-source-params|.
+		Default value: {}
+
+		" e.g.
+		call ddc#custom#patch_global('sourceParams', {
+		    \ 'around': {'max': 8},
+		    \ })
+
+					*ddc-options-sourceParams*
+filterOptions
+		It is a dictionary that maps filter names to its options.
+		See also |ddc-filter-options|.
+		Default value: {}
+
+		" e.g.
+		call ddc#custom#patch_global('filterOptions', {
+		    \ 'matcher_head': {},
+		    \ })
+
+					*ddc-options-sourceParams*
+filterParams
+		It is a dictionary that maps filter names to its parameters.
+		See also |ddc-filter-params|.
+		Default value: {}
+
+		" e.g.
+		call ddc#custom#patch_global('filterParams', {
+		    \ 'matcher_head': {},
+		    \ })
 
 ------------------------------------------------------------------------------
 FUNCTIONS 						*ddc-functions*
@@ -116,47 +162,57 @@ ddc#register_source({dict})
 
 CUSTOM FUNCTIONS 					*ddc-custom-functions*
 
-							*ddc#custom#global()*
-ddc#custom#global({option-name}, {value})
-ddc#custom#global({dict})
+							*ddc#custom#patch_global()*
+ddc#custom#patch_global({option-name}, {value})
+ddc#custom#patch_global({dict})
 		Set {option-name} option to {value}.
 		If {dict} is available, the key is {option-name} and the value
-		is {value}.
+		is {value}. See |ddc-options| for available {option-name}.
 
-							*ddc#custom#local()*
-ddc#custom#local({option-name}, {value})
-ddc#custom#local({dict})
-		The buffer local version of |ddc#custom#global()|.
+							*ddc#custom#patch_filetype()*
+ddc#custom#patch_filetype({filetype}, {option-name}, {value})
+ddc#custom#patch_filetype({filetype}, {dict})
+		Set options used for filetypes. {filetype} accepts a string or
+		a list of strings. Options are {dict} or {'{option-name}': {value}}.
 
-							*ddc#custom#source()*
-ddc#custom#source({source-name}, {option-name}, {value})
-ddc#custom#source({source-name}, {dict})
-		Set {source-name} source specialized {option-name}
-		to {value}. You may specify multiple sources with
-		separating "," in {source-name}.
-		If {source-name} is "_", sources default option will be
-		change.
-		If {dict} is available, the key is {option-name} and the value
-		is {value}.
-		Note: You must call it before using ddc.
+							*ddc#custom#patch_buffer()*
+ddc#custom#patch_buffer({option-name}, {value})
+ddc#custom#patch_buffer({dict})
+		Set local options on current buffer.  The arguments are the same
+		as for |ddc#custom#patch_global|.
 
 ------------------------------------------------------------------------------
 KEY MAPPINGS 						*ddc-key-mappings*
 
 ==============================================================================
 EXAMPLES						*ddc-examples*
+
 >
-	" Use around source.
-	call ddc#custom#global('sources', { '_': ['around'] })
+" Customize global settings
+" Use around source.
+call ddc#custom#patch_global('sources', ['around'])
+" Enable default matcher.
+call ddc#custom#patch_global('sourceOptions', {
+      \ '_': {'matchers': ['matcher_head']},
+      \ }
+" Change source options
+call ddc#custom#patch_global('sourceOptions', {
+      \ 'around': {'matchers': ['matcher_head'], 'mark': 'A'},
+      \ })
+call ddc#custom#patch_global('sourceParams', {
+      \ 'around': {'maxSize': 500},
+      \ })
 
-	" Enable default matcher.
-	call ddc#custom#source('_', 'matchers', ['matcher_head'])
+" Customize settings on a filetype
+call ddc#custom#patch_filetype(['c', 'cpp'], 'sources', ['around', 'clangd'])
+call ddc#custom#patch_filetype(['c', 'cpp'], 'sourceOptions', {
+      \ 'clangd': {'mark': 'C'},
+      \ }
+call ddc#custom#patch_filetype('markdown', 'sourceParams', {
+      \ 'around': {'maxSize': 100},
+      \ })
 
-	" Change source mark.
-	call ddc#custom#source('around', 'mark', ['A'])
-
-	" Use ddc.
-	call ddc#enable()
+call ddc#enable()
 <
 
 ==============================================================================
@@ -169,28 +225,34 @@ around							*ddc-source-around*
 ------------------------------------------------------------------------------
 SOURCE OPTIONS						*ddc-source-options*
 
-mark		(String)			(Optional)
-		The mark of a source.
+mark		(String)
+		A text icon indicating the source displayed with the candidate.
 		Note: If the source set candidate menu, the source must set
 		it.  If the attribute is empty string, the candidate menu will
 		be disabled.
 
-		Default: same with source name
+		Default: ""
 
-==============================================================================
-CREATE SOURCE						*ddc-create-source*
+matchers		([string])
+		It is a list of registered filter names that used with this source.
+		Candidates will be processed in the order you specify here.
+		Default: []
 
-To create source, you should read other sources implementation.
+sorters		([string])
+		It is a list of registered filter names that used with this source.
+		Candidates will be processed in the order you specify here.
+		Default: []
 
-The files must be registerd by |ddc#register_source()|.
-Source class must extend the Base class.
-
-Note: The sources must be written in Typescript language.
-
-Note: If you call Vim functions in your source, it is not asynchronous.
+converters		([string])
+		It is a list of registered filter names that used with this source.
+		Candidates will be processed in the order you specify here.
+		Default: []
 
 ------------------------------------------------------------------------------
-SOURCE ATTRIBUTES					*ddc-source-attributes*
+SOURCE PARAMS					*ddc-source-params*
+
+These are the parameters that each source can have.  You can select the
+behavior and tune the performance.
 
 
 ==============================================================================
@@ -206,6 +268,24 @@ configure them to use ddc.
 				    	    	*ddc-filter-matcher_head*
 matcher_head	Head matching matcher.
 
+==============================================================================
+CREATE SOURCE						*ddc-create-source*
+
+To create source, you should read other sources implementation.
+
+The files must be registerd by |ddc#register_source()|.
+Source class must extend the Base class.
+
+Note: The sources must be written in Typescript language.
+
+Note: If you call Vim functions in your source, it is not asynchronous.
+
+
+------------------------------------------------------------------------------
+SOURCE ATTRIBUTES					*ddc-source-attributes*
+
+------------------------------------------------------------------------------
+CANDIDATE ATTRIBUTES					*ddc-candidate-attributes*
 
 ==============================================================================
 CREATE FILTER						*ddc-create-filter*
@@ -235,7 +315,7 @@ plugins.  You can donate money to help me!
 https://github.com/sponsors/Shougo
 
 
-Q: Why ddc.vim does not include any of sources/matchers/sorters/converters?
+Q: Why does ddc.vim not include any sources/matchers/sorters/converters?
 
 A: Because I cannot determine the best default
 sources/matchers/sorters/converters.
@@ -245,11 +325,11 @@ You must define your defaults by configuration.
 ddc.vim does not conflict with your defaults.
 
 
-Q: Why ddc.vim has not source default attributes?
+Q. Why do sources have no default options?
 
-A: Because users should config sources perfectly.  If source has the default,
-users must check the source has the default value.
-The config should work as users config.  It may increase configuration cost.
+A: Because users can customize sources perfectly.  If a source has the default,
+users have to check them.  It increases configuration cost.
+The config should work as users config.
 
 
 ==============================================================================

--- a/doc/ddc.txt
+++ b/doc/ddc.txt
@@ -325,7 +325,7 @@ You must define your defaults by configuration.
 ddc.vim does not conflict with your defaults.
 
 
-Q. Why do sources have no default options?
+Q: Why do sources have no default options?
 
 A: Because users can customize sources perfectly.  If a source has the default,
 users have to check them.  It increases configuration cost.


### PR DESCRIPTION
状態の扱いを設計してたら巨大プルリクになっていまいました。
採用してもらえたらドキュメントも書き直します。いかがですか。

## "設定" 再構成
* 各種設定についてソース登録, フィルタ登録, 設定を行う関数が実行される順序に左右されたくない

* グローバル設定, filetype設定, バッファローカル設定がある
  - この設定は使うソースとその順序を持つ
  - 名前に紐付けてソースの設定とフィルタの設定を持つ
  - これ以外の動的な設定は思いつかなかった

* ソースごとの設定がある
  * ddcが使う設定
    - 紐付けるフィルタについてソースがデフォルトを持つ
      - そのためにはフィルタは世界で一意な通名をもつ必要がある 衝突したらユーザが適切なnameに変える
    - ユーザがソースに紐付けるフィルタを設定できる
    - ソースがmarkのデフォルトを提供する
    - ユーザがmarkを上書きできる
  * ソースが使う設定
    - ソースが自身のパラメータを持つ
    - ユーザがソースのパラメータをいじる

* フィルタごとの設定がある
  * ddcが使う設定
  * ソースが使う設定

* 設定値をtypescript側に持つ
* Ddcが提供するデフォルト値をソースのデフォルト値で上書きする。さらにそれをユーザ指定値で上書きする
* "設定"の一番上に`Custom`を使う


以上を踏まえこの3つを実装した
1. changedイベントごとに状態を取得する
2. 現在のバッファ状態における設定を得る
3. 設定に基づいてソース, フィルタを動かす

とりあえず以下のように名前をつけた
* TextChangedのたびに変わってそうなものをContext
* ユーザが設定しないと変わらないものをCustomとそのOptionsに持つ
* ソースが持つことができる任意のパラメータでddcで型付けできないものをParams

## どうでもいいこと
* plugin/にテスト用aroundソース設定が残ってる
* echodocからやり方変わってないので問題は起こってないんだと思うですけど
autocmdもnotifyも手での編集をブロックしないはずなので
最後の結果が表示されるのは最後の編集の計算が最も遅く終わったからにすぎないはず
発火時に数値インクリメントして最大値持つ結果だけを採用みたいな形でも解決するがまあいらない
ストリームやキャンセル考えたほうが有意義
* interfaceが型に関連する型を持てないので返り値型にベースクラスを使わざるをえず結果ユーザパラメータがRecord<string, unknown>になる

よろしくおねがいします。