### PR TITLE
`filterCandidates`は`SourceOptions`を必要とする

### DIFF
--- a/denops/ddc/context.ts
+++ b/denops/ddc/context.ts
@@ -374,6 +374,7 @@ Deno.test("mergeDdcOptions", () => {
     })
     .patchBuffer(2, {});
   assertEquals(custom.get("typescript", 1), {
+    ...defaultDdcOptions(),
     sources: ["around", "foo"],
     sourceOptions: {},
     filterOptions: {},
@@ -392,6 +393,7 @@ Deno.test("mergeDdcOptions", () => {
     },
   });
   assertEquals(custom.get("typescript", 2), {
+    ...defaultDdcOptions(),
     sources: [],
     sourceOptions: {},
     filterOptions: {},
@@ -407,6 +409,7 @@ Deno.test("mergeDdcOptions", () => {
     },
   });
   assertEquals(custom.get("cpp", 1), {
+    ...defaultDdcOptions(),
     sources: ["around", "foo"],
     sourceOptions: {},
     filterOptions: {},

--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -73,31 +73,6 @@ function filterArgs(
   return [optionsOf(filter), paramsOf(filter)];
 }
 
-type FiltersUsed = {
-  matchers: string[];
-  sorters: string[];
-  converters: string[];
-};
-
-function filtersUsed(options: DdcOptions, sourceName: string): FiltersUsed {
-  const filtersUsed = foldMerge(merge, empty, [
-    options.sourceOptions["_"],
-    options.sourceOptions[sourceName],
-  ]);
-  return filtersUsed;
-
-  function merge(a: FiltersUsed, b: Partial<FiltersUsed>): FiltersUsed {
-    return { ...a, ...b };
-  }
-  function empty(): FiltersUsed {
-    return {
-      matchers: [],
-      sorters: [],
-      converters: [],
-    };
-  }
-}
-
 export class Ddc {
   private sources: Record<string, BaseSource> = {};
   private filters: Record<string, BaseFilter> = {};
@@ -135,10 +110,9 @@ export class Ddc {
       const filterCandidates = await this.filterCandidates(
         denops,
         context,
-        filtersUsed(options, source.name),
+        sourceOptions,
         options.filterOptions,
         options.filterParams,
-        sourceOptions,
         sourceCandidates,
       );
       const result: DdcCandidate[] = filterCandidates.map((c: Candidate) => (
@@ -161,17 +135,16 @@ export class Ddc {
   private async filterCandidates(
     denops: Denops,
     context: Context,
-    filtersUsed: FiltersUsed,
+    sourceOptions: SourceOptions,
     filterOptions: Record<string, Partial<FilterOptions>>,
     filterParams: Record<string, Partial<Record<string, unknown>>>,
-    sourceOptions: SourceOptions,
     cdd: Candidate[],
   ): Promise<Candidate[]> {
     const foundFilters = (names: string[]) =>
       names.map((name) => this.filters[name]).filter((x) => x);
-    const matchers = foundFilters(filtersUsed.matchers);
-    const sorters = foundFilters(filtersUsed.sorters);
-    const converters = foundFilters(filtersUsed.converters);
+    const matchers = foundFilters(sourceOptions.matchers);
+    const sorters = foundFilters(sourceOptions.sorters);
+    const converters = foundFilters(sourceOptions.converters);
 
     for (const matcher of matchers) {
       const [o, p] = filterArgs(filterOptions, filterParams, matcher);
@@ -287,33 +260,4 @@ Deno.test("filterArgs", () => {
     min: 100,
     max: 999,
   }]);
-});
-
-Deno.test("filtersUsed", () => {
-  const userOptions: DdcOptions = {
-    ...defaultDdcOptions(),
-    sources: [],
-    sourceOptions: {
-      "_": {
-        matchers: ["matcher_head"],
-      },
-      "around": {
-        matchers: [],
-        sorters: ["O(1)"],
-      },
-    },
-    filterOptions: {},
-    sourceParams: {},
-    filterParams: {},
-  };
-  assertEquals(filtersUsed(userOptions, "around"), {
-    matchers: [],
-    sorters: ["O(1)"],
-    converters: [],
-  });
-  assertEquals(filtersUsed(userOptions, "foo"), {
-    matchers: ["matcher_head"],
-    sorters: [],
-    converters: [],
-  });
 });

--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -7,6 +7,7 @@ import {
   SourceOptions,
 } from "./types.ts";
 import {
+  defaultDdcOptions,
   foldMerge,
   mergeFilterOptions,
   mergeFilterParams,
@@ -194,7 +195,7 @@ export class Ddc {
 
 Deno.test("sourceArgs", () => {
   const userOptions: DdcOptions = {
-    completionMode: "inline",
+    ...defaultDdcOptions(),
     sources: ["strength"],
     sourceOptions: {
       "_": {
@@ -213,8 +214,6 @@ Deno.test("sourceArgs", () => {
         min: 100,
       },
     },
-    filterOptions: {},
-    filterParams: {},
   };
   class S extends BaseSource {
     params() {
@@ -236,6 +235,7 @@ Deno.test("sourceArgs", () => {
   source.name = "strength";
   const [o, p] = sourceArgs(userOptions, source);
   assertEquals(o, {
+    ...defaultSourceOptions(),
     mark: "S",
     matchers: ["matcher_head"],
     maxCandidates: 500,
@@ -244,6 +244,7 @@ Deno.test("sourceArgs", () => {
   });
   assertEquals(p.by_, undefined);
   assertEquals(p, {
+    ...defaultSourceParams(),
     min: 100,
     max: 999,
   });
@@ -280,13 +281,17 @@ Deno.test("filterArgs", () => {
   const filter = new F();
   filter.name = "/dev/null";
   assertEquals(filterArgs(userOptions, userParams, filter), [{
-    placeholder: undefined,
-  }, { min: 100, max: 999 }]);
+    ...defaultFilterOptions(),
+  }, {
+    ...defaultFilterParams(),
+    min: 100,
+    max: 999,
+  }]);
 });
 
 Deno.test("filtersUsed", () => {
   const userOptions: DdcOptions = {
-    completionMode: "inline",
+    ...defaultDdcOptions(),
     sources: [],
     sourceOptions: {
       "_": {


### PR DESCRIPTION
* `FiltersUsed`を廃止した
  -`filterCandidate`にはsourceOptionsを解体して渡したかったが`FiltersUsed`以外にも必要なoptionsがあるようなのでsourceOptionsを渡す元の形に戻した
* options追加でテストの書き換えを必要とするのは無理があったのでdefaultを使うようにした