### PR TITLE
EXAMPLE: Use `ReadableStream` as an interface of source

### DIFF
--- a/denops/ddc/base/source.ts
+++ b/denops/ddc/base/source.ts
@@ -20,7 +20,7 @@ export abstract class BaseSource {
     context: Context,
     options: SourceOptions,
     params: Record<string, unknown>,
-  ): Promise<Candidate[]>;
+  ): Promise<ReadableStream<Candidate[]>>;
 
   params(): Record<string, unknown> {
     return {} as Record<string, unknown>;

--- a/denops/ddc/deps.ts
+++ b/denops/ddc/deps.ts
@@ -1,5 +1,8 @@
 export type { Denops } from "https://deno.land/x/denops_std@v1.0.0/mod.ts#^";
-export { execute } from "https://deno.land/x/denops_std@v1.0.0/helper/mod.ts#^";
+export {
+  batch,
+  execute,
+} from "https://deno.land/x/denops_std@v1.0.0/helper/mod.ts#^";
 export * as vars from "https://deno.land/x/denops_std@v1.0.0/variable/mod.ts#^";
 export * as autocmd from "https://deno.land/x/denops_std@v1.0.0/autocmd/mod.ts#^";
 export { ensureObject } from "https://deno.land/x/unknownutil@v0.1.1/mod.ts#^";


### PR DESCRIPTION
This is not perfect while I don't really understand the core concept of ddc **so do not merge it directly** (e.g. I don't think I properly handle `completePos` in this PR)

- Use `ReadableStream` as an interface of the source so that developers can define an incremental (gradual) asynchronous source
- Use `TransformStream` as like `map` and `filter` function of an array so that candidates are incrementally (gradually) proceeded
- Use `WritableStream` as a target of entire streams so that changes are incrementally (gradually) applied to Vim

These streams are defined well so you'll be able to use some common tools like https://github.com/MeirionHughes/web-streams-extensions (it does not support Deno though) in the future.

Related #13 

I've marked it as DRAFT to prevent accidental merge.