### PR TITLE
Gather candidates of sources concurrently and improve `around` source as an example `batch` usage

### DIFF
--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -174,7 +174,10 @@ export class Ddc {
       return [completePos, candidates] as const;
     }));
     // Remove invalid source and prepend default result ([0, []])
-    const fs = [[0, [] as DdcCandidate[]], ...rs.filter((v) => v)] as [number, DdcCandidate[]][];
+    const fs = [[0, [] as DdcCandidate[]], ...rs.filter((v) => v)] as [
+      number,
+      DdcCandidate[],
+    ][];
     // XXX: Should't we use the smallest completePos instead?
     const completePos = fs[fs.length - 1][0];
     // Flatten candidates

--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -173,8 +173,8 @@ export class Ddc {
       ));
       return [completePos, candidates] as const;
     }));
-    // Remove invalid source and add default result ([0, []])
-    const fs = [...rs.filter((v) => v), [0, [] as DdcCandidate[]]] as [number, DdcCandidate[]][];
+    // Remove invalid source and prepend default result ([0, []])
+    const fs = [[0, [] as DdcCandidate[]], ...rs.filter((v) => v)] as [number, DdcCandidate[]][];
     // XXX: Should't we use the smallest completePos instead?
     const completePos = fs[fs.length - 1][0];
     // Flatten candidates

--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -174,7 +174,7 @@ export class Ddc {
       return [completePos, candidates] as const;
     }));
     // Remove invalid source and add default result ([0, []])
-    const fs = [...rs.filter((v) => v) as [number, DdcCandidate[]][], [0, []]];
+    const fs = [...rs.filter((v) => v), [0, [] as DdcCandidate[]]] as [number, DdcCandidate[]][];
     // XXX: Should't we use the smallest completePos instead?
     const completePos = fs[fs.length - 1][0];
     // Flatten candidates

--- a/denops/ddc/deps.ts
+++ b/denops/ddc/deps.ts
@@ -1,5 +1,9 @@
 export type { Denops } from "https://deno.land/x/denops_std@v1.0.0/mod.ts#^";
-export { execute } from "https://deno.land/x/denops_std@v1.0.0/helper/mod.ts#^";
+export {
+  batch,
+  execute,
+} from "https://deno.land/x/denops_std@v1.0.0/helper/mod.ts#^";
+export * as fn from "https://deno.land/x/denops_std@v1.0.0/function/mod.ts#^";
 export * as vars from "https://deno.land/x/denops_std@v1.0.0/variable/mod.ts#^";
 export * as autocmd from "https://deno.land/x/denops_std@v1.0.0/autocmd/mod.ts#^";
 export { ensureObject } from "https://deno.land/x/unknownutil@v0.1.1/mod.ts#^";


### PR DESCRIPTION
1. Gather candidates of sources concurrently
2. Improve performance of `around` source by using `batch`
3. Use `Set` to remove duplicated words prior to create candidates of `around` source

![Kapture 2021-07-31 at 13 46 09](https://user-images.githubusercontent.com/546312/127728900-fb174413-f06e-4040-97b4-db0440d27681.gif)

### Note

It seems `getCompletePosition()` use `-1` as an invalid value thus if a `completePos` of the last source is `-1`, completion die. This behavior is consistent prior to this PR and I'm not sure what is the correct approach to determine `completePos` of the entire completion thus I just keep the previous behavior.