### PR TITLE
Fix getBuffer

### DIFF
--- a/denops/ddc/app.ts
+++ b/denops/ddc/app.ts
@@ -48,7 +48,7 @@ export async function main(denops: Denops) {
       return Promise.resolve(contextBuilder.getFiletype());
     },
     getBuffer(): Promise<Record<number, Partial<DdcOptions>>> {
-      return Promise.resolve(contextBuilder.getFiletype());
+      return Promise.resolve(contextBuilder.getBuffer());
     },
     async _cacheWorld(arg1: unknown): Promise<unknown> {
       return await contextBuilder._cacheWorld(denops, arg1 as string);

--- a/denops/ddc/context.ts
+++ b/denops/ddc/context.ts
@@ -207,21 +207,15 @@ async function cacheWorld(denops: Denops, event: string): Promise<World> {
       (await denops.call("getbufvar", "%", "&iminsert")) as number;
     return !enabledEskk && iminsert == 1;
   })();
+  const bufnr = denops.call("bufnr") as Promise<number>;
+  const ft = denops.call("getbufvar", "%", "&filetype") as Promise<string>;
   const mode: string = event == "InsertEnter"
     ? "i"
     : (await denops.call("mode")) as string;
-  const input: Promise<string> = (async () => {
-    return (await denops.call("ddc#get_input", mode)) as string;
-  })();
-  const bufnr: Promise<number> = (async () => {
-    return (await denops.call("bufnr")) as number;
-  })();
-  const filetype: Promise<string> = (async () => {
-    return (await denops.call("getbufvar", "%", "&filetype")) as string;
-  })();
+  const input = denops.call("ddc#get_input", mode) as Promise<string>;
   return {
     bufnr: await bufnr,
-    filetype: await filetype,
+    filetype: await ft,
     event: event,
     mode: mode,
     input: await input,


### PR DESCRIPTION
## Changes
* Fix getBuffer
* We can write `as Promise<concrete type>`

## Unchanged
```
const enabledEskk = (await fn.exists(denops, "*eskk#is_enabled") &&
  denops.call("eskk#is_enabled"));
```
Have you checked the type and operator binding order? I don't have any reason to believe it, but it seemed suspicious to me.