### PR TITLE
Enable selecting autocmds for onEvent() of sources and filters

### DIFF
--- a/denops/ddc/app.ts
+++ b/denops/ddc/app.ts
@@ -76,13 +76,11 @@ export async function main(denops: Denops) {
       if (!maybe) return;
       const [context, options] = maybe;
 
-      if (event == "InsertEnter") {
-        await ddc.onEvent(
-          denops,
-          context,
-          options,
-        );
-      }
+      await ddc.onEvent(
+        denops,
+        context,
+        options,
+      );
 
       if (
         options.autoCompleteEvents.indexOf(event) < 0 && event != "Refresh"
@@ -96,21 +94,13 @@ export async function main(denops: Denops) {
 
   await autocmd.group(denops, "ddc", (helper: autocmd.GroupHelper) => {
     helper.remove("*");
-    for (
-      const event of [
-        "InsertEnter",
-        "InsertLeave",
-        "TextChangedI",
-        "TextChangedP",
-      ]
-    ) {
-      helper.define(
-        event as autocmd.AutocmdEvent,
-        "*",
-        `call denops#notify('${denops.name}', 'onEvent',["${event}"])`,
-      );
-    }
   });
+  ddc.registerAutocmd(denops, [
+    "InsertEnter",
+    "InsertLeave",
+    "TextChangedI",
+    "TextChangedP",
+  ]);
 
   async function doCompletion(
     denops: Denops,

--- a/denops/ddc/base/filter.ts
+++ b/denops/ddc/base/filter.ts
@@ -9,6 +9,7 @@ import { Denops } from "../deps.ts";
 
 export abstract class BaseFilter {
   name = "";
+  events = ["InsertEnter"];
 
   async onInit(
     _denops: Denops,

--- a/denops/ddc/base/source.ts
+++ b/denops/ddc/base/source.ts
@@ -4,6 +4,7 @@ import { Denops } from "../deps.ts";
 export abstract class BaseSource {
   name = "";
   isBytePos = false;
+  events = ["InsertEnter"];
 
   async onInit(
     _denops: Denops,

--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -101,14 +101,9 @@ export class Ddc {
     return names.map((n) => this.filters[n]).filter((v) => v);
   }
 
-  async registerAutocmd(
-    denops: Denops,
-    events: string[],
-  ) {
+  async registerAutocmd(denops: Denops, events: string[]) {
     await autocmd.group(denops, "ddc", (helper: autocmd.GroupHelper) => {
-      for (
-        const event of events
-      ) {
+      for (const event of events) {
         if (!this.events.includes(event)) {
           helper.define(
             event as autocmd.AutocmdEvent,


### PR DESCRIPTION
I'm creating [buffer source](https://github.com/matsui54/ddc-buffer) and this source's cache should be made on autocmd-events other than InsertEnter.
In this PR, I tried to enable selecting whatever autocmds-events that sources and filters need.