### PR TITLE
Proposal: Add explicit typing to sourceParams

### DIFF
--- a/denops/ddc/base/source.ts
+++ b/denops/ddc/base/source.ts
@@ -65,7 +65,9 @@ export abstract class BaseSource<SourceParams = Record<string, never>> {
     {}: GatherCandidatesArguments<SourceParams>,
   ): Promise<Candidate[]>;
 
-  abstract params(): SourceParams;
+  params(): SourceParams {
+    return {} as SourceParams;
+  }
 }
 
 export function defaultSourceOptions(): SourceOptions {

--- a/denops/ddc/base/source.ts
+++ b/denops/ddc/base/source.ts
@@ -7,38 +7,38 @@ import {
 } from "../types.ts";
 import { Denops } from "../deps.ts";
 
-export type OnInitArguments = {
+export type OnInitArguments<SourceParams> = {
   denops: Denops;
   sourceOptions: SourceOptions;
-  sourceParams: Record<string, unknown>;
+  sourceParams: SourceParams;
 };
 
-export type OnEventArguments = {
+export type OnEventArguments<SourceParams> = {
   denops: Denops;
   context: Context;
   options: DdcOptions;
   sourceOptions: SourceOptions;
-  sourceParams: Record<string, unknown>;
+  sourceParams: SourceParams;
 };
 
-export type GetCompletePositionArguments = {
+export type GetCompletePositionArguments<SourceParams> = {
   denops: Denops;
   context: Context;
   options: DdcOptions;
   sourceOptions: SourceOptions;
-  sourceParams: Record<string, unknown>;
+  sourceParams: SourceParams;
 };
 
-export type GatherCandidatesArguments = {
+export type GatherCandidatesArguments<SourceParams> = {
   denops: Denops;
   context: Context;
   options: DdcOptions;
   sourceOptions: SourceOptions;
-  sourceParams: Record<string, unknown>;
+  sourceParams: SourceParams;
   completeStr: string;
 };
 
-export abstract class BaseSource {
+export abstract class BaseSource<SourceParams = Record<string, never>> {
   name = "";
   isBytePos = false;
   events: DdcEvent[] = [];
@@ -47,12 +47,12 @@ export abstract class BaseSource {
   // Use overload methods
   apiVersion = 3;
 
-  async onInit(_args: OnInitArguments): Promise<void> {}
+  async onInit(_args: OnInitArguments<SourceParams>): Promise<void> {}
 
-  async onEvent(_args: OnEventArguments): Promise<void> {}
+  async onEvent(_args: OnEventArguments<SourceParams>): Promise<void> {}
 
   getCompletePosition(
-    args: GetCompletePositionArguments,
+    args: GetCompletePositionArguments<SourceParams>,
   ): Promise<number> {
     const matchPos = args.context.input.search(
       new RegExp("(" + args.options.keywordPattern + ")$"),
@@ -62,12 +62,10 @@ export abstract class BaseSource {
   }
 
   abstract gatherCandidates(
-    {}: GatherCandidatesArguments,
+    {}: GatherCandidatesArguments<SourceParams>,
   ): Promise<Candidate[]>;
 
-  params(): Record<string, unknown> {
-    return {} as Record<string, unknown>;
-  }
+  abstract params(): SourceParams;
 }
 
 export function defaultSourceOptions(): SourceOptions {


### PR DESCRIPTION
The idea here would be enforce more rigor when it comes to source params. The proposal here would require devs to implement a params function that conforms to the annotated types when they build their Source class.

The downside, I am not sure we can define the function for users, however, at the very least, most can just implement with something that returns an empty object.

I don't know much about how deno libraries are managed, so not sure if there are some tests I need to run these against or whatever. Ultimately I don't actually care too much if this PR is rejected because there might be a better way to do this, but figure I would get the discussion started here.