### PR TITLE
Add type parameters for classes extended by users.

### DIFF
--- a/denops/ddc/base/filter.ts
+++ b/denops/ddc/base/filter.ts
@@ -8,32 +8,34 @@ import {
 } from "../types.ts";
 import { Denops } from "../deps.ts";
 
-export type OnInitArguments = {
+export type OnInitArguments<Params extends Record<string, unknown>> = {
   denops: Denops;
   filterOptions: FilterOptions;
-  filterParams: Record<string, unknown>;
+  filterParams: Params;
 };
 
-export type OnEventArguments = {
+export type OnEventArguments<Params extends Record<string, unknown>> = {
   denops: Denops;
   context: Context;
   options: DdcOptions;
   filterOptions: FilterOptions;
-  filterParams: Record<string, unknown>;
+  filterParams: Params;
 };
 
-export type FilterArguments = {
+export type FilterArguments<Params extends Record<string, unknown>> = {
   denops: Denops;
   context: Context;
   options: DdcOptions;
   sourceOptions: SourceOptions;
   filterOptions: FilterOptions;
-  filterParams: Record<string, unknown>;
+  filterParams: Params;
   completeStr: string;
   candidates: Candidate[];
 };
 
-export abstract class BaseFilter {
+export abstract class BaseFilter<
+  Params extends Record<string, unknown> = Record<string, unknown>,
+> {
   name = "";
   events: DdcEvent[] = [];
   isInitialized = false;
@@ -41,15 +43,13 @@ export abstract class BaseFilter {
   // Use overload methods
   apiVersion = 3;
 
-  async onInit(_args: OnInitArguments): Promise<void> {}
+  async onInit(_args: OnInitArguments<Params>): Promise<void> {}
 
-  async onEvent(_args: OnEventArguments): Promise<void> {}
+  async onEvent(_args: OnEventArguments<Params>): Promise<void> {}
 
-  abstract filter({}: FilterArguments): Promise<Candidate[]>;
+  abstract filter({}: FilterArguments<Params>): Promise<Candidate[]>;
 
-  params(): Record<string, unknown> {
-    return {} as Record<string, unknown>;
-  }
+  abstract params(): Params;
 }
 
 export function defaultFilterOptions(): FilterOptions {

--- a/denops/ddc/types.ts
+++ b/denops/ddc/types.ts
@@ -62,22 +62,28 @@ export type FilterOptions = {
   placeholder: void;
 };
 
-export type Candidate = {
+export type Candidate<
+  UserData extends Record<string, unknown> = Record<string, unknown>,
+> = {
   word: string;
   abbr?: string;
   menu?: string;
   info?: string;
   kind?: string;
   dup?: boolean;
-  "user_data"?: DdcUserData;
+  // To prevent users from supplying internal variables.
+  "user_data"?: UserData & { __sourceName?: never };
 };
 
 // For internal type
-export type DdcCandidate = Candidate & {
-  icase: boolean;
-  equal: boolean;
-};
-
 export type DdcUserData = {
   __sourceName: string;
+  [userKey: string]: unknown;
 };
+
+export type DdcCandidate =
+  & Candidate<DdcUserData>
+  & {
+    icase: boolean;
+    equal: boolean;
+  };

--- a/doc/ddc.txt
+++ b/doc/ddc.txt
@@ -562,12 +562,12 @@ getCompletePosition	(function)			(Optional)
 		It is called to get the position of the current completion.
 
 				*ddc-source-attribute-onCompleteDone*
-onCompleteDone		(function)			(Required)
+onCompleteDone		(function)			(Optional)
 		Called after the completion.
 		It is useful to substitute text after completion.
 
 				*ddc-source-attribute-onEvent*
-onEvent			(function)			(Required)
+onEvent			(function)			(Optional)
 		Called for the autocommands.
 		It is useful to make cache.
 
@@ -576,7 +576,7 @@ onInit			(function)			(Optional)
 		Called before call source functions.
 
 				*ddc-source-attribute-params*
-params			(function)			(Optional)
+params			(function)			(Required)
 		Called to get source params.
 
 


### PR DESCRIPTION
Related: https://github.com/Shougo/ddc.vim/pull/46, https://github.com/Shougo/ddc.vim/pull/52

I'll add comments to describe some of my decisions.

```ts
// -----------------------------------------------------------------
// source
// -----------------------------------------------------------------

// optional, but required when using UserData.
// User can skip defining by Params = {} or Params = Record<string, unknown>
type Params = {
  myParam: number
}

type UserData = {
  myData: string;
}

class MySource extends BaseSource<Params, UserData> {
  async gatherCandidates() {
    return [
      {
        word: "a",
        user_data: {
          myData: "data",

          // type error
          // myData: 3

          // Prevented by type checking even if defined in UserData.
          // type error
          // __sourceName: "data",
        },
      },
    ]
  }

  params() {
    return {
      myParam: 3

      // type error
      // myParam: "3"
    }

    // type error
    // return { }
  }

  // type error
  // params(): Record<string, unknown> { ... }
}

// ok
// class MySource extends BaseSource { ... }
// ok
// class MySource extends BaseSource<Record<string, unknown>> { ... }
// ok
// class MySource extends BaseSource<Record<string, unknown>, UserData> { ... }
// ok
// class MySource extends BaseSource<{}, UserData> { ... }

// type error: Type 'string' does not satisfy the constraint 'Record<string, unknown>'
// class MySource extends BaseSource<{}, string> { ... }

// -----------------------------------------------------------------
// filter
// -----------------------------------------------------------------

type Params = {
  myParam: number
}
class MyFilter extends BaseFilter<Params> {
  async filter() {
    return [
      {
        word: "a",
        user_data: {
          // anything ok because there may be any type of user_data from all sources.

          // type error
          // __sourceName: "data",
        },
      },
    ]
  }

  params() {
    return {
      myParam: 3

      // type error
      // myParam: "3"
    }

    // type error
    // return { }
  }

  // type error
  // params(): Record<string, unknown> { ... }
}

// ok
// class MyFilter extends BaseFilter { ... }

// -----------------------------------------------------------------
```
