### PR TITLE
Fix types

### DIFF
--- a/denops/ddc/base/source.ts
+++ b/denops/ddc/base/source.ts
@@ -23,7 +23,7 @@ export type OnEventArguments<Params extends Record<string, unknown>> = {
 
 export type OnCompleteDoneArguments<
   Params extends Record<string, unknown>,
-  UserData extends Record<string, unknown>,
+  UserData extends unknown,
 > = {
   denops: Denops;
   context: Context;
@@ -31,7 +31,7 @@ export type OnCompleteDoneArguments<
   sourceOptions: SourceOptions;
   sourceParams: Params;
   // To prevent users from accessing internal variables.
-  userData: UserData & { __sourceName?: never };
+  userData: UserData;
 };
 
 export type GetCompletePositionArguments<
@@ -56,7 +56,7 @@ export type GatherCandidatesArguments<Params extends Record<string, unknown>> =
 
 export abstract class BaseSource<
   Params extends Record<string, unknown> = Record<string, unknown>,
-  UserData extends Record<string, unknown> = Record<string, unknown>,
+  UserData extends unknown = unknown,
 > {
   name = "";
   isBytePos = false;

--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -506,7 +506,7 @@ function charposToBytepos(input: string, pos: number): number {
 
 function sourceArgs<
   Params extends Record<string, unknown>,
-  UserData extends Record<string, unknown>,
+  UserData extends unknown,
 >(
   options: DdcOptions,
   source: BaseSource<Params, UserData>,
@@ -647,7 +647,7 @@ async function callSourceOnEvent(
 
 async function callSourceOnCompleteDone<
   Params extends Record<string, unknown>,
-  UserData extends Record<string, unknown>,
+  UserData extends unknown,
 >(
   source: BaseSource<Params, UserData>,
   denops: Denops,
@@ -724,7 +724,7 @@ async function callSourceGetCompletePosition(
 
 async function callSourceGatherCandidates<
   Params extends Record<string, unknown>,
-  UserData extends Record<string, unknown>,
+  UserData extends unknown,
 >(
   source: BaseSource<Params, UserData>,
   denops: Denops,

--- a/denops/ddc/types.ts
+++ b/denops/ddc/types.ts
@@ -63,7 +63,7 @@ export type FilterOptions = {
 };
 
 export type Candidate<
-  UserData extends Record<string, unknown> = Record<string, unknown>,
+  UserData extends unknown = unknown,
 > = {
   word: string;
   abbr?: string;
@@ -71,13 +71,11 @@ export type Candidate<
   info?: string;
   kind?: string;
   dup?: boolean;
-  "user_data"?: UserData | string;
+  "user_data"?: UserData;
 };
 
 // For internal type
-export type DdcUserData = {
-  [userKey: string]: unknown;
-};
+export type DdcUserData = unknown;
 
 export type DdcCandidate =
   & Candidate<DdcUserData>


### PR DESCRIPTION
current typing allows passing `string` for `UserData={a:string}`.
change to `Record<string, unknown> | string` seems good, but user_data can get any type, so we can use `number` for example. Thus I used `unknown`.