### PR TITLE
Add backspaceCompletion option

### DIFF
--- a/denops/ddc/app.ts
+++ b/denops/ddc/app.ts
@@ -144,9 +144,10 @@ export async function main(denops: Denops) {
     context: Context,
     options: DdcOptions,
   ): Promise<boolean> {
-    // Note: Don't complete when backspace, because of completion flicker.
+    // Note: Don't complete when backspace by default, because of completion flicker.
     const prevInput = await vars.g.get(denops, "ddc#_prev_input") as string;
-    const checkBackSpace = (context.input != prevInput &&
+    const checkBackSpace = (!options.backspaceCompletion &&
+      context.input != prevInput &&
       context.input.length + 1 == prevInput.length &&
       prevInput.startsWith(context.input));
     if (checkBackSpace && options.completionMode == "popupmenu") {

--- a/denops/ddc/context.ts
+++ b/denops/ddc/context.ts
@@ -40,6 +40,7 @@ export function defaultDdcOptions(): DdcOptions {
   return {
     autoCompleteDelay: 0,
     autoCompleteEvents: ["InsertEnter", "TextChangedI", "TextChangedP"],
+    backspaceCompletion: false,
     completionMode: "popupmenu",
     filterOptions: {},
     filterParams: {},

--- a/denops/ddc/types.ts
+++ b/denops/ddc/types.ts
@@ -29,6 +29,7 @@ type CompletionMode = "inline" | "popupmenu" | "manual";
 export type DdcOptions = {
   autoCompleteDelay: number;
   autoCompleteEvents: DdcEvent[];
+  backspaceCompletion: boolean;
   completionMode: CompletionMode;
   filterOptions: Record<string, Partial<FilterOptions>>;
   filterParams: Record<string, Partial<Record<string, unknown>>>;

--- a/doc/ddc.txt
+++ b/doc/ddc.txt
@@ -93,6 +93,15 @@ autoCompleteEvents
 
 		Default: ["InsertEnter", "TextChangedI", "TextChangedP"]
 
+				*ddc-option-backspaceCompletion*
+backspaceCompletion
+		If it is enabled, ddc.vim will complete even when backspace is
+		typed.
+		It is disabled by default since backspace completion will
+		cause completion flicker.
+
+		Default: v:false
+
 						*ddc-option-completionMode*
 completionMode
 		The completion mode. It must be following string.


### PR DESCRIPTION
- Add `backspaceCompletion` option which enables us to be able to make `ddc.vim` complete even when `backspace` will be typed.
    - Even though the backspace completion causes the completion flicker, I'd like to make `ddc.vim` automatically complete when the backspace key is typed without the extra typing.

Is this kind of control capability for the backspace completion acceptable...?