### PR TITLE
perf: use single dynamic import with dynamic code generation

### DIFF
--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -178,7 +178,7 @@ export class Ddc {
     if (isSource) {
       const sources = (await globpath(
         ["denops/@ddc-sources/", "denops/ddc-sources/"],
-        files,
+        files.map((file) => this.aliasSources[file] ?? file),
       )).filter((path) => !(path in this.checkPaths));
 
       await Promise.all(sources.map((path) => {
@@ -187,7 +187,7 @@ export class Ddc {
     } else {
       const filters = (await globpath(
         ["denops/@ddc-filters/", "denops/ddc-filters/"],
-        files,
+        files.map((file) => this.aliasFilters[file] ?? file),
       )).filter((path) => !(path in this.checkPaths));
 
       await Promise.all(filters.map((path) => {

--- a/denops/ddc/deps.ts
+++ b/denops/ddc/deps.ts
@@ -12,6 +12,7 @@ export {
   ensureObject,
   ensureString,
 } from "https://deno.land/x/unknownutil@v0.1.1/mod.ts#^";
+export * as base64 from "https://deno.land/std@0.111.0/encoding/base64.ts";
 export { assertEquals } from "https://deno.land/std@0.111.0/testing/asserts.ts#^";
 export { parse, toFileUrl } from "https://deno.land/std@0.111.0/path/mod.ts#^";
 export {


### PR DESCRIPTION
- fix: load alias resolved name
- feat: bundle dynamic imports to single one

(I worked based on https://github.com/Shougo/ddc.vim/pull/70)

Measurement with capture software with using 12 sources + 3 filters,

main: 3.415s (import itself: sum 3000ms)
this: 2.085s (import itself: 700ms + 150ms)

but I think you can make it faster with loading all sources at once.

references:

- https://github.com/denoland/deno/issues/12519