### PR TITLE
Fix filter.onInit() was duplicate called

### DIFF
--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -133,7 +133,6 @@ export class Ddc {
     const addFilter = (name: string) => {
       const filter = new mod.Filter();
       filter.name = name;
-      filter.onInit({ denops });
       this.filters[filter.name] = filter;
       if (filter.events && filter.events.length != 0) {
         this.registerAutocmd(denops, filter.events);


### PR DESCRIPTION
Currently filter.onInit() was called two times.

https://github.com/Shougo/ddc.vim/blob/f2ec802e9cc8bb0d94fcbff6de29b736bc904944/denops/ddc/ddc.ts#L136
https://github.com/Shougo/ddc.vim/blob/f2ec802e9cc8bb0d94fcbff6de29b736bc904944/denops/ddc/ddc.ts#L712

This PR is delete first call because I thought forgotten to delete that.