### PR TITLE
Ensure onEvent() is always called.

### DIFF
--- a/denops/ddc/app.ts
+++ b/denops/ddc/app.ts
@@ -91,9 +91,9 @@ export async function main(denops: Denops) {
     async manualComplete(arg1: unknown): Promise<void> {
       const sources = arg1 as string[];
 
-      const maybe = await contextBuilder.createContext(denops, "Manual");
-      if (!maybe) return;
-      const [context, options] = maybe;
+      const [skip, context, options] = await contextBuilder
+        .createContext(denops, "Manual");
+      if (skip) return;
       if (sources.length != 0) {
         options.sources = sources;
       }
@@ -103,17 +103,17 @@ export async function main(denops: Denops) {
     },
     async onEvent(arg1: unknown): Promise<void> {
       const event = arg1 as DdcEvent;
-      const maybe = await contextBuilder.createContext(denops, event);
-      if (!maybe) return;
-      const [context, options] = maybe;
-
-      cbContext.revoke();
+      const [skip, context, options] = await contextBuilder
+        .createContext(denops, event);
       await ddc.onEvent(
         denops,
         context,
         cbContext.createOnCallback(),
         options,
       );
+      if (skip) return;
+
+      cbContext.revoke();
 
       if (event != "InsertEnter" && await fn.mode(denops) == "n") {
         return;
@@ -174,9 +174,9 @@ export async function main(denops: Denops) {
     async onCompleteDone(arg1: unknown, arg2: unknown): Promise<void> {
       const sourceName = arg1 as string;
       const userData = arg2 as DdcUserData;
-      const maybe = await contextBuilder.createContext(denops, "CompleteDone");
-      if (!maybe) return;
-      const [context, options] = maybe;
+      const [skip, context, options] = await contextBuilder
+        .createContext(denops, "CompleteDone");
+      if (skip) return;
 
       cbContext.revoke();
       await ddc.onCompleteDone(

--- a/denops/ddc/context.ts
+++ b/denops/ddc/context.ts
@@ -308,18 +308,18 @@ export class ContextBuilder {
   async createContext(
     denops: Denops,
     event: DdcEvent,
-  ): Promise<null | [Context, DdcOptions]> {
+  ): Promise<[boolean, Context, DdcOptions]> {
     const world = await this._cacheWorld(denops, event);
     const old = this.lastWorld;
     this.lastWorld = world;
+    let skip = false;
     if (
-      event != "Manual" &&
-      event != "Initialize" && event != "CompleteDone" &&
-      isNegligible(old, world)
+      (event != "Manual" &&
+        event != "Initialize" && event != "CompleteDone" &&
+        isNegligible(old, world)) || world.isLmap || world.changedByCompletion
     ) {
-      return null;
+      skip = true;
     }
-    if (world.isLmap || world.changedByCompletion) return null;
 
     const context = {
       changedTick: world.changedTick,
@@ -329,7 +329,11 @@ export class ContextBuilder {
       lineNr: world.lineNr,
       nextInput: world.nextInput,
     };
-    return [context, await this._getUserOptions(denops, world)];
+    return [
+      skip,
+      context,
+      await this._getUserOptions(denops, world),
+    ];
   }
 
   async _getUserOptions(denops: Denops, world: World): Promise<DdcOptions> {


### PR DESCRIPTION
Probrem is that `onEvent()` isn't always called on some events when the `World` is the same.
For example, `InsertLeave` event isn't called, because the `input` is the same, which means the `World` is the same.

All events must always be called.