### PR TITLE
Use getcmdpos() for getting column in command line

### DIFF
--- a/autoload/ddc.vim
+++ b/autoload/ddc.vim
@@ -129,7 +129,8 @@ function! ddc#_complete() abort
       let input = getline('.')[: g:ddc#_complete_pos]
       let displaywidth = max(map(copy(g:ddc#_candidates),
             \ { _, val -> strdisplaywidth(input . val.word) })) + 1
-      if displaywidth >= &l:textwidth || virtcol('.') >= displaywidth
+      let col = mode() ==# 'c' ? getcmdpos() : virtcol('.')
+      if displaywidth >= &l:textwidth || col >= displaywidth
         return
       endif
     endif


### PR DESCRIPTION
## Problem
When using ddc.vim in search command line with `'incsearch'` on, sometimes completion menu doesn't appear.

## Solution
Return value of `virtcol()` can be cursor position in normal mode when `'incsearch'` is on, so use `getcmdpos()` instead.
