### PR TITLE
Prevent JS RegExp counting capture group number to make it fully controllable for users

### DIFF
--- a/denops/ddc/base/source.ts
+++ b/denops/ddc/base/source.ts
@@ -83,7 +83,7 @@ export abstract class BaseSource<
     args: GetCompletePositionArguments<Params>,
   ): Promise<number> {
     const matchPos = args.context.input.search(
-      new RegExp("(" + args.options.keywordPattern + ")$"),
+      new RegExp("(?:" + args.options.keywordPattern + ")$"),
     );
     const completePos = matchPos != null ? matchPos : -1;
     return Promise.resolve(completePos);

--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -340,7 +340,7 @@ export class Ddc {
       );
       const forceCompletion = o.forceCompletionPattern.length != 0 &&
         context.input.search(
-            new RegExp("(" + o.forceCompletionPattern + ")$"),
+            new RegExp("(?:" + o.forceCompletionPattern + ")$"),
           ) != -1;
       // Note: If forceCompletion and not matched getCompletePosition(),
       // Use cursor position instead.


### PR DESCRIPTION
If intended, it's ok.

When users want to specify `('")(?:.(?!\1))*` for `forceCompletionPattern`, as it denotes _yet closed string literals_, this should be passed as `('")(?:(?!\2))`, as group numbers are counted up by 1.

The problem is that users can't intuitively use theses options with capturing.