### PR TITLE
Support incomplete items of LSP server

### DIFF
--- a/denops/ddc/base/source.ts
+++ b/denops/ddc/base/source.ts
@@ -1,6 +1,7 @@
 import {
   Candidate,
   Context,
+  DdcCompleteItems,
   DdcEvent,
   DdcOptions,
   OnCallback,
@@ -91,7 +92,7 @@ export abstract class BaseSource<
 
   abstract gatherCandidates(
     {}: GatherCandidatesArguments<Params>,
-  ): Promise<Candidate<UserData>[]>;
+  ): Promise<DdcCompleteItems<UserData>>;
 
   abstract params(): Params;
 }

--- a/denops/ddc/base/source.ts
+++ b/denops/ddc/base/source.ts
@@ -1,5 +1,4 @@
 import {
-  Candidate,
   Context,
   DdcCompleteItems,
   DdcEvent,

--- a/denops/ddc/base/source.ts
+++ b/denops/ddc/base/source.ts
@@ -58,6 +58,7 @@ export type GatherCandidatesArguments<Params extends Record<string, unknown>> =
     sourceOptions: SourceOptions;
     sourceParams: Params;
     completeStr: string;
+    isIncomplete?: boolean;
   };
 
 export abstract class BaseSource<

--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -2,6 +2,7 @@ import {
   Candidate,
   Context,
   DdcCandidate,
+  DdcCompleteItems,
   DdcExtType,
   DdcOptions,
   DdcUserData,
@@ -48,6 +49,7 @@ type DdcResult = {
   completeStr: string;
   prevInput: string;
   lineNr: number;
+  isIncomplete: boolean;
 };
 
 export class Ddc {
@@ -350,6 +352,13 @@ export class Ddc {
         ? byteposToCharpos(context.input, pos)
         : pos;
       const completeStr = context.input.slice(completePos);
+      const incomplete = this.prevResults[s.name]?.isIncomplete ?? false;
+      const triggerForIncomplete = !forceCompletion && incomplete &&
+        context.lineNr == this.prevResults[s.name].lineNr;
+      if (triggerForIncomplete) {
+        context.event = "Incomplete";
+        delete this.prevResults[s.name];
+      }
       if (
         completePos < 0 ||
         (!forceCompletion &&
@@ -377,7 +386,7 @@ export class Ddc {
         o.isVolatile
       ) {
         // Not matched.
-        const scs = await callSourceGatherCandidates(
+        const item = await callSourceGatherCandidates(
           s,
           denops,
           context,
@@ -387,16 +396,29 @@ export class Ddc {
           p,
           completeStr,
         );
-        if (!scs.length) {
-          return;
+        if ("isIncomplete" in item) {
+          if (!item.items.length) {
+            return;
+          }
+          this.prevResults[s.name] = {
+            candidates: item.items.concat(),
+            completeStr: completeStr,
+            prevInput: prevInput,
+            lineNr: context.lineNr,
+            isIncomplete: item.isIncomplete,
+          };
+        } else {
+          if (!item.length) {
+            return;
+          }
+          this.prevResults[s.name] = {
+            candidates: item.concat(),
+            completeStr: completeStr,
+            prevInput: prevInput,
+            lineNr: context.lineNr,
+            isIncomplete: false,
+          };
         }
-
-        this.prevResults[s.name] = {
-          candidates: scs.concat(),
-          completeStr: completeStr,
-          prevInput: prevInput,
-          lineNr: context.lineNr,
-        };
       }
 
       const fcs = await this.filterCandidates(
@@ -824,7 +846,7 @@ async function callSourceGatherCandidates<
   sourceOptions: SourceOptions,
   sourceParams: Params,
   completeStr: string,
-): Promise<Candidate<UserData>[]> {
+): Promise<DdcCompleteItems<UserData>> {
   await checkSourceOnInit(source, denops, sourceOptions, sourceParams);
 
   try {

--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -355,10 +355,6 @@ export class Ddc {
       const incomplete = this.prevResults[s.name]?.isIncomplete ?? false;
       const triggerForIncomplete = !forceCompletion && incomplete &&
         context.lineNr == this.prevResults[s.name].lineNr;
-      if (triggerForIncomplete) {
-        context.event = "Incomplete";
-        delete this.prevResults[s.name];
-      }
       if (
         completePos < 0 ||
         (!forceCompletion &&
@@ -378,7 +374,7 @@ export class Ddc {
       const prevInput = context.input.slice(0, completePos);
 
       if (
-        !result ||
+        !result || triggerForIncomplete ||
         prevInput != result.prevInput ||
         !completeStr.startsWith(result.completeStr) ||
         context.lineNr != result.lineNr ||
@@ -395,6 +391,7 @@ export class Ddc {
           o,
           p,
           completeStr,
+          triggerForIncomplete,
         );
         if ("isIncomplete" in item) {
           if (!item.items.length) {
@@ -846,6 +843,7 @@ async function callSourceGatherCandidates<
   sourceOptions: SourceOptions,
   sourceParams: Params,
   completeStr: string,
+  isIncomplete: boolean,
 ): Promise<DdcCompleteItems<UserData>> {
   await checkSourceOnInit(source, denops, sourceOptions, sourceParams);
 
@@ -858,6 +856,7 @@ async function callSourceGatherCandidates<
       sourceOptions,
       sourceParams,
       completeStr,
+      isIncomplete,
     });
     return await deadline(promise, sourceOptions.timeout);
   } catch (e: unknown) {

--- a/denops/ddc/types.ts
+++ b/denops/ddc/types.ts
@@ -7,7 +7,8 @@ export type DdcExtType = "source" | "filter";
 export type DdcEvent =
   | autocmd.AutocmdEvent
   | "Initialize"
-  | "Manual";
+  | "Manual"
+  | "Incomplete";
 
 export type SourceName = string;
 
@@ -88,6 +89,13 @@ export type Candidate<
   dup?: boolean;
   "user_data"?: UserData;
   highlights?: PumHighlight[];
+};
+
+export type DdcCompleteItems<
+  UserData extends unknown = unknown,
+> = Candidate<UserData>[] | {
+  items: Candidate<UserData>[];
+  isIncomplete: boolean;
 };
 
 // For internal type

--- a/denops/ddc/types.ts
+++ b/denops/ddc/types.ts
@@ -7,8 +7,7 @@ export type DdcExtType = "source" | "filter";
 export type DdcEvent =
   | autocmd.AutocmdEvent
   | "Initialize"
-  | "Manual"
-  | "Incomplete";
+  | "Manual";
 
 export type SourceName = string;
 


### PR DESCRIPTION
# Problem description
Lsp candidates is sometimes incomplete, which means all candidates are not sent from lsp server.
For example, if you set `'forceCompletionPattern': "<"` and type `#include <` in C files, you can see some include files, but if you type more word to narrow down the candidates, you will notice that not all candidates are shown. In the gif, I want to select `string.h`, but there isn't such file.
This problem occurs in both ddc-nvim-lsp and ddc-vim-lsp.

![ddc-incomplete-before](https://user-images.githubusercontent.com/63794197/154935209-d93143b6-1c43-4642-8b5a-674f2d99378e.gif)

# Cause of the problem
This problem is caused by the specification of lsp.
As shown [here](https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#completionList), when `CompletionList.isIncomplete == true`, the candidates sent from the lsp server is incomplete. Therefore, we need to send `textDocument/completion` request again when the user types more characters.

# Solution
In order to solve this problem, ddc.vim must know if the candidates from the sources is incomplete, and gather candidates again when the additional character is typed.
This behavior cannot be achieved by neither user's config nor modification of `ddc-nvim-lsp`. Also, this PR doesn't break backward compatibility.
The same method is also used in nvim-cmp and asyncomplete.vim.

https://github.com/hrsh7th/nvim-cmp/blob/13d64460cba64950aff41e230cc801225bd9a3e2/lua/cmp/source.lua#L264-L267
https://github.com/prabirshrestha/asyncomplete-lsp.vim/blob/f6d6a6354ff279ba707c20292aef0dfaadc436a3/plugin/asyncomplete-lsp.vim#L102

Fixed:
![ddc-incomplete-fixed](https://user-images.githubusercontent.com/63794197/154938603-01d9204b-c257-4c23-b6d6-5c5bfda1995e.gif)

To solve the problem, ddc-vim-lsp and ddc-nvim-lsp must also be fixed. If you merge this PR, I will send PR to them.