### PR TITLE
Fix duplicate helptags.

### DIFF
--- a/doc/ddc.txt
+++ b/doc/ddc.txt
@@ -380,12 +380,6 @@ ddc#custom#set_context({filetype}, {func})
 		    \   'sources': ['nextword', 'around'],
 		    \ } : {} })
 
-						*ddc#custom#set_global()*
-ddc#custom#set_global({dict})
-		Overwrites all global config options.
-		The {dict} key is {option-name} and the value is {value}. See
-		|ddc-options| for available {option-name}.
-
 ------------------------------------------------------------------------------
 KEY MAPPINGS 						*ddc-key-mappings*
 


### PR DESCRIPTION
helptagsが重複していました。
最近のコミットした方を残しました。
いま残ってる方が`ddc#custom#set_global()`のヘルプの修正版でしょうか？
よろしければ、マージお願いします。