### PR TITLE
fix completion problems that occur in some case

### DIFF
--- a/denops/ddc/context.ts
+++ b/denops/ddc/context.ts
@@ -310,7 +310,8 @@ async function cacheWorld(denops: Denops, event: DdcEvent): Promise<World> {
 function isNegligible(older: World, newer: World): boolean {
   return older.bufnr == newer.bufnr &&
     older.filetype == newer.filetype &&
-    older.input == newer.input;
+    older.input == newer.input &&
+    older.event == newer.event;
 }
 
 export class ContextBuilder {


### PR DESCRIPTION
When used with [kana/vim-smartinput](https://github.com/kana/vim-smartinput) and [kana/vim-smartchr](https://github.com/kana/vim-smartchr) in the following configuration, completion of structure members, etc. may not be displayed.

<details>
<summary>minimal.vim</summary>

```vim
let plugins = [
       \ "/home/erw7/.config/nvim/dein/repos/github.com/vim-denops/denops.vim",
       \ "/home/erw7/.config/nvim/dein/repos/github.com/Shougo/ddc.vim",
       \ "/home/erw7/.config/nvim/dein/repos/github.com/Shougo/ddc-nvim-lsp",
       \ "/home/erw7/.config/nvim/dein/repos/github.com/Shougo/ddc-sorter_rank",
       \ "/home/erw7/.config/nvim/dein/repos/github.com/Shougo/ddc-matcher_head",
       \ "/home/erw7/.config/nvim/dein/repos/github.com/neovim/nvim-lspconfig",
       \ "/home/erw7/.config/nvim/dein/repos/github.com/kana/vim-smartinput",
       \ "/home/erw7/.config/nvim/dein/repos/github.com/kana/vim-smartchr",
       \]

let &rtp = &rtp . ',' . join(plugins, ',')

filetype plugin indent on

call ddc#custom#patch_global({
      \  'sources' : ['nvim-lsp', ],
      \  'sourceOptions' : {
      \    '_' : {
      \      'sorters' : ['sorter_rank', ],
      \      'matchers' : ['matcher_head', ],
      \    },
      \    'nvim-lsp' :  {'forceCompletionPattern' : '\.\w*|->\w*|:\w*', },
      \  },
      \})
call ddc#enable()

call smartinput#map_to_trigger('i', '.', '.', '.')
call smartinput#define_rule({
      \  'at' : '\%#',
      \  'char' : '.',
      \  'input' : '<C-R>=smartchr#loop(".", "->", "...")<CR>',
      \})

lua << EOF
  local lspconfig = require'lspconfig'
  lspconfig.clangd.setup{}
EOF
```
</details>
