### PR TITLE
fix: suppress error of no matching autocommands

### DIFF
--- a/autoload/ddc.vim
+++ b/autoload/ddc.vim
@@ -18,6 +18,7 @@ function! ddc#enable() abort
 
   augroup ddc
     autocmd!
+    autocmd User DDCReady :
     autocmd CompleteDone * call ddc#complete#_on_complete_done()
     autocmd User PumCompleteDone call ddc#complete#_on_complete_done()
     autocmd InsertLeave * call ddc#_hide('InsertLeave')


### PR DESCRIPTION
There are cases where the error message "No matching autocommands" is shows.
So I added a placeholder for the autocommand.

I rejected the method of adding `silent` to `doautocmd` because it has side effects.
Or there was a way to check with `exists()`, but I chose this simple implementation.

## Problem

The following error message is shows.

```
No matching autocommands: User DDCReady
```

## Expected

No error message is shows.

## Reproduce

*testvimrc*
```vim
set nocompatible

set rtp^=path/to/denops.vim
set rtp^=path/to/ddc.vim

call ddc#enable()
```

Run `vim -u testvimrc`.