### PR TITLE
fix: keep custom parameters when restart multiple times

### DIFF
--- a/autoload/ddc.vim
+++ b/autoload/ddc.vim
@@ -100,8 +100,6 @@ function! s:stopped() abort
     for custom in g:ddc#_customs
       call ddc#_notify(custom.method, custom.args)
     endfor
-
-    let g:ddc#_customs = []
   endif
 endfunction
 


### PR DESCRIPTION
The custom parameters will be kept even after the second restart.

## Problem

The custom parameters is empty when denops.vim is restarted twice.

## Expected

Keep the custom parameters.

## Reproduce

vimrc
```vim
" minimum vimrc
set nocompatible

set rtp^=path/to/denops.vim
set rtp^=path/to/ddc.vim

call ddc#custom#patch_global('autoCompleteDelay', 42)
call ddc#enable()

" testing
autocmd VimEnter * call timer_start(3000, funcref('Test'))
function! Test(...) abort
  echom "0:" ddc#custom#get_global()
  call denops#server#restart()
  call timer_start(3000, funcref('Test1'))
endfunction
function! Test1(...) abort
  echom "1:" ddc#custom#get_global()
  call denops#server#restart()
  call timer_start(3000, funcref('Test2'))
endfunction
function! Test2(...) abort
  echom "2:" ddc#custom#get_global()
endfunction
```

Run `vim -u testvimrc`.

Show result `:messages`.
```
0: {'autoCompleteDelay': 42}
[denops] Server stopped (-1). Restarting...
[denops] Server is restarted.
1: {'autoCompleteDelay': 42}
[denops] Server stopped (-1). Restarting...
[denops] Server is restarted.
2: {}
```