### PR TITLE
fix: register on server restarted even if enabled after DenopsReady

### DIFF
--- a/autoload/ddc.vim
+++ b/autoload/ddc.vim
@@ -30,10 +30,9 @@ function! ddc#enable() abort
   let g:ddc#_started = reltime()
 
   " Note: ddc.vim must be registered manually.
+  autocmd ddc User DenopsReady silent! call ddc#_register()
   if exists('g:loaded_denops') && denops#server#status() ==# 'running'
     silent! call ddc#_register()
-  else
-    autocmd ddc User DenopsReady silent! call ddc#_register()
   endif
 endfunction
 function! ddc#enable_cmdline_completion() abort


### PR DESCRIPTION
Always add a register call to `DenopsReady`.

## Problem

If `ddc#enable()` is called after `DenopsReady`, ddc is not enabled after denops server restart.

## Expected

Re-enable ddc.

## Reproduce

vimrc
```vim
" minimum vimrc
set nocompatible

set rtp^=path/to/denops.vim
set rtp^=path/to/ddc.vim

autocmd User DenopsReady ++once call ddc#enable()
" instead :call ddc#enable()

" testing
augroup testing
  autocmd!
  autocmd User DDCReady echomsg "[DDCReady fired]"
augroup END
autocmd VimEnter * call timer_start(3000, { -> denops#server#restart() })
```

Run `vim -u vimrc`.

Show result `:messages`.
```
[DDCReady fired]
[denops] Server stopped (-1). Restarting...
[denops] Server is restarted.
```

Expected result.
```
[DDCReady fired]
[denops] Server stopped (-1). Restarting...
[denops] Server is restarted.
[DDCReady fired]
```