### PR TITLE
Fix ddc#syntax#get()

### DIFF
--- a/autoload/ddc/syntax.vim
+++ b/autoload/ddc/syntax.vim
@@ -11,9 +11,7 @@ endfunction
 function! ddc#syntax#get() abort
   let curpos = getcurpos()[1:2]
   return &l:syntax !=# '' ? s:get_syn_names([curpos[0], curpos[1] - 1]) :
-        \ has('nvim') ? s:get_treesitter_nodes([curpos[0] - 1,
-        \   col('$') == col('.') ? curpos[1] - 2 : curpos[1] - 1]) :
-        \ []
+        \ has('nvim') ? v:lua.vim.treesitter.get_captures_at_cursor(0) :  []
 endfunction
 
 function! s:get_syn_names(curpos) abort
@@ -35,9 +33,4 @@ function! s:get_syn_names(curpos) abort
     " Ignore error
   endtry
   return names
-endfunction
-
-function! s:get_treesitter_nodes(curpos) abort
-  return map(v:lua.vim.treesitter.get_captures_at_pos(
-        \ 0, a:curpos[0], a:curpos[1]), { _, val -> val.capture })
 endfunction


### PR DESCRIPTION
Use `vim.treesitter.get_captures_at_cursor()` instead of `vim.treesitter.get_captures_at_pos()`.

`vim.treesitter.get_captures_at_cursor()` is available from neovim 0.8. this is the same as `s:get_treesitter_nodes()`.

Also, `s:get_treesitter_nodes()` has a problem.

1. Set [shougo-s-github's toml query](https://github.com/Shougo/shougo-s-github/tree/master/vim/after/queries/toml)
2. Open some toml file like below:

```toml
[[plugins]]
repo = 'Shougo/dein.vim'
hook_add = '''
  let g:tmp = "tmp"
'''
```

3. Excute `:lua print(vim.inspect(vim.treesitter.get_captures_at_pos(0, 4, 1)))`
4. You can see:

```txt
{ {
    capture = "property",
    metadata = {}
  }, {
    capture = "string",
    metadata = {}
  }, {
    capture = "none",
    metadata = {
      [15] = {
        range = { 2, 14, 4, 0 }
      }
    }
  } }
```

This contains `15` (number) as dictionary key. Vim script can't interpret number as a key, so `s:get_treesitter_nodes` will be broken.