### PR TITLE
Avoid side effects of ddc-cmdline

### DIFF
--- a/autoload/ddc/map.vim
+++ b/autoload/ddc/map.vim
@@ -80,6 +80,22 @@ function ddc#map#insert_item(number) abort
 
   const mode = mode()
 
+  " Avoid the menu redisplay
+  if mode() ==# 'c'
+    if '#User#PumCompleteDonePre'->exists()
+      doautocmd <nomodeline> User PumCompleteDonePre
+    endif
+    const cmdline = getcmdline()
+    const prev_input = g:ddc#_complete_pos == 0
+          \ ? ''
+          \ : cmdline[: g:ddc#_complete_pos - 1]
+    const next_input = cmdline[s:col() - 1 :]
+    call setcmdline(prev_input . word . next_input,
+          \ g:ddc#_complete_pos + 1 + word->len())
+    call ddc#complete#_on_complete_done(v:completed_item)
+    return ''
+  endif
+
   " Call CompleteDone later.
   if mode ==# 'i'
     autocmd ddc TextChangedI * ++once


### PR DESCRIPTION
This strange phenomenon occurs when using `ddc#map#insert_item()` after `ddc#enable_cmdline_completion()`.

![ddc#map#insert_item](https://github.com/Shougo/ddc.vim/assets/82267684/39a700dc-94ff-4d0b-b407-f298ec3388aa)

This is due to this autocmd firing and must be controlled.
https://github.com/Shougo/ddc.vim/blob/fb4e6519eae9d3a19c4c16c975e8e97e83596048/autoload/ddc.vim#L41-L44