### PR TITLE
fix: wasn't consider `sourceOptions.sources` is object at onCompleteDone

### DIFF
--- a/denops/ddc/app.ts
+++ b/denops/ddc/app.ts
@@ -194,13 +194,29 @@ export function main(denops: Denops) {
         .createContext(denops, "CompleteDone");
       if (skip) return;
 
+      if (context.mode === "c") {
+        // Use cmdlineSources instead
+        if (Array.isArray(options.cmdlineSources)) {
+          options.sources = options.cmdlineSources;
+        } else {
+          const cmdType = await fn.getcmdtype(denops) as string;
+          if (options.cmdlineSources[cmdType]) {
+            options.sources = options.cmdlineSources[cmdType];
+          }
+        }
+      }
+      const userSource =
+        options.sources.find((source) =>
+          (is.Record(source) ? source.name : source) === sourceName
+        ) ?? sourceName;
+
       cbContext.revoke();
       await ddc.onCompleteDone(
         denops,
         context,
         cbContext.createOnCallback(),
         options,
-        sourceName,
+        userSource,
         userData,
       );
     },

--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -163,13 +163,13 @@ export class Ddc {
     context: Context,
     onCallback: OnCallback,
     options: DdcOptions,
-    sourceName: SourceName,
+    userSource: UserSource,
     userData: DdcUserData,
   ): Promise<void> {
     const [source, sourceOptions, sourceParams] = await this.getSource(
       denops,
       options,
-      sourceName,
+      userSource,
     );
     if (!source || !source.onCompleteDone) {
       return;


### PR DESCRIPTION
# Problems summary

Wasn't apply params/options of `sourceOptions.sources` if source definition is object.

## Expected

Passing params/options to onCompleteDone arguments. For example in this case display test object.

## Environment Information (Required!)
- ddc.vim version(SHA1): 6c1de37d138d376326c9bbc1ed0b66d6a244189a

- OS: Arch Linux

- neovim/Vim `:version` output:

```
NVIM v0.10.0-dev-672+g33e1a8cd7-dirty
Build type: Debug
LuaJIT 2.1.0-beta3
```

## Provide a minimal init.vim/vimrc without plugin managers (Required!)

```vim
set rtp+=/data/vim/repos/github.com/vim-denops/denops.vim
set rtp+=/data/vim/repos/github.com/Shougo/ddc.vim
set rtp+=/data/vim/repos/github.com/Shougo/ddc-ui-native
set noshowmode

call ddc#enable()
call ddc#register('source', expand('<sfile>:h') .. '/a.ts')
call ddc#custom#patch_global(#{
\   sources: [
\     #{
\       name: 'a',
\       params: #{
\         test: 'test',
\       },
\     },
\   ],
\   ui: 'native',
\ })
```

and place this source to same directory of init.vim named "a.ts"

```typescript
import {
  BaseSource,
  BaseSourceParams,
} from "https://deno.land/x/ddc_vim@v3.9.0/types.ts";

type Params = Record<never, never>;

export class Source extends BaseSource<Params> {
  override async gather() {
    return [{
      word: "hoge",
      user_data: {},
    }];
  }

  override async onCompleteDone(args: {
    sourceParams: BaseSourceParams;
  }) {
    console.log(args.sourceParams);
  }

  override params() {
    return {};
  }
}
```

## How to reproduce the problem from neovim/Vim startup (Required!)

1. Run `nvim -u init.vim`.
2. Insert "ho" and insert candidate. (`<C-n>`)
3. Some action that `CompleteDone` fires.

`{}` was displayed.

