### PR TITLE
[WIP] Resolve circular reference

### DIFF
--- a/denops/ddc/app.ts
+++ b/denops/ddc/app.ts
@@ -1,6 +1,7 @@
 import { Ddc } from "./ddc.ts";
-import { ContextBuilder, type ContextCallbacks } from "./context.ts";
+import { ContextBuilderImpl } from "./context.ts";
 import type {
+  ContextCallbacks,
   DdcEvent,
   DdcExtType,
   DdcItem,
@@ -26,7 +27,7 @@ import { toFileUrl } from "jsr:@std/path@~1.0.2/to-file-url";
 export const main: Entrypoint = (denops: Denops) => {
   const loader = new Loader();
   const ddc = new Ddc(loader);
-  const contextBuilder = new ContextBuilder();
+  const contextBuilder = new ContextBuilderImpl();
   const cbContext = createCallbackContext();
   const lock = new Lock(0);
   let queuedEvent: DdcEvent | null = null;

--- a/denops/ddc/base/config.ts
+++ b/denops/ddc/base/config.ts
@@ -1,5 +1,4 @@
-import type { ContextBuilder } from "../context.ts";
-import type { DdcExtType } from "../types.ts";
+import type { ContextBuilder, DdcExtType } from "../types.ts";
 
 import type { Denops } from "jsr:@denops/std@~7.1.0";
 

--- a/denops/ddc/base/filter.ts
+++ b/denops/ddc/base/filter.ts
@@ -1,4 +1,5 @@
 import type {
+  BaseParams,
   Context,
   DdcEvent,
   DdcOptions,
@@ -10,15 +11,13 @@ import type {
 
 import type { Denops } from "jsr:@denops/std@~7.1.0";
 
-export type BaseFilterParams = Record<string, unknown>;
-
-export type OnInitArguments<Params extends BaseFilterParams> = {
+export type OnInitArguments<Params extends BaseParams> = {
   denops: Denops;
   filterOptions: FilterOptions;
   filterParams: Params;
 };
 
-export type OnEventArguments<Params extends BaseFilterParams> = {
+export type OnEventArguments<Params extends BaseParams> = {
   denops: Denops;
   context: Context;
   onCallback: OnCallback;
@@ -27,7 +26,7 @@ export type OnEventArguments<Params extends BaseFilterParams> = {
   filterParams: Params;
 };
 
-export type FilterArguments<Params extends BaseFilterParams> = {
+export type FilterArguments<Params extends BaseParams> = {
   denops: Denops;
   context: Context;
   onCallback: OnCallback;
@@ -39,7 +38,7 @@ export type FilterArguments<Params extends BaseFilterParams> = {
   items: Item[];
 };
 
-export abstract class BaseFilter<Params extends BaseFilterParams> {
+export abstract class BaseFilter<Params extends BaseParams> {
   name = "";
   isInitialized = false;
   apiVersion = 4;

--- a/denops/ddc/base/source.ts
+++ b/denops/ddc/base/source.ts
@@ -1,4 +1,5 @@
 import type {
+  BaseParams,
   Context,
   DdcEvent,
   DdcGatherItems,
@@ -10,31 +11,26 @@ import type {
   SourceOptions,
 } from "../types.ts";
 import { convertKeywordPattern } from "../utils.ts";
-import type { Loader } from "../loader.ts";
 
 import type { Denops } from "jsr:@denops/std@~7.1.0";
 
-export type BaseSourceParams = Record<string, unknown>;
-
-export type OnInitArguments<Params extends BaseSourceParams> = {
+export type OnInitArguments<Params extends BaseParams> = {
   denops: Denops;
   sourceOptions: SourceOptions;
   sourceParams: Params;
-  loader: Loader;
 };
 
-export type OnEventArguments<Params extends BaseSourceParams> = {
+export type OnEventArguments<Params extends BaseParams> = {
   denops: Denops;
   context: Context;
   onCallback: OnCallback;
   options: DdcOptions;
   sourceOptions: SourceOptions;
   sourceParams: Params;
-  loader: Loader;
 };
 
 export type OnCompleteDoneArguments<
-  Params extends BaseSourceParams,
+  Params extends BaseParams,
   UserData extends unknown = unknown,
 > = {
   denops: Denops;
@@ -43,13 +39,12 @@ export type OnCompleteDoneArguments<
   options: DdcOptions;
   sourceOptions: SourceOptions;
   sourceParams: Params;
-  loader: Loader;
   // To prevent users from accessing internal variables.
   userData: UserData;
 };
 
 export type GetPreviewerArguments<
-  Params extends BaseSourceParams,
+  Params extends BaseParams,
   UserData extends unknown = unknown,
 > = {
   denops: Denops;
@@ -59,34 +54,31 @@ export type GetPreviewerArguments<
   sourceParams: Params;
   item: Item<UserData>;
   previewContext: PreviewContext;
-  loader: Loader;
 };
 
-export type GetCompletePositionArguments<Params extends BaseSourceParams> = {
+export type GetCompletePositionArguments<Params extends BaseParams> = {
   denops: Denops;
   context: Context;
   onCallback: OnCallback;
   options: DdcOptions;
   sourceOptions: SourceOptions;
   sourceParams: Params;
-  loader: Loader;
 };
 
-export type GatherArguments<Params extends BaseSourceParams> = {
+export type GatherArguments<Params extends BaseParams> = {
   denops: Denops;
   context: Context;
   onCallback: OnCallback;
   options: DdcOptions;
   sourceOptions: SourceOptions;
   sourceParams: Params;
-  loader: Loader;
   completePos: number;
   completeStr: string;
   isIncomplete?: boolean;
 };
 
 export abstract class BaseSource<
-  Params extends BaseSourceParams,
+  Params extends BaseParams,
   UserData extends unknown = unknown,
 > {
   name = "";

--- a/denops/ddc/base/ui.ts
+++ b/denops/ddc/base/ui.ts
@@ -1,16 +1,20 @@
-import type { Context, DdcItem, DdcOptions, UiOptions } from "../types.ts";
+import type {
+  BaseParams,
+  Context,
+  DdcItem,
+  DdcOptions,
+  UiOptions,
+} from "../types.ts";
 
 import type { Denops } from "jsr:@denops/std@~7.1.0";
 
-export type BaseUiParams = Record<string, unknown>;
-
-export type OnInitArguments<Params extends BaseUiParams> = {
+export type OnInitArguments<Params extends BaseParams> = {
   denops: Denops;
   uiOptions: UiOptions;
   uiParams: Params;
 };
 
-export type SkipCompletionArguments<Params extends BaseUiParams> = {
+export type SkipCompletionArguments<Params extends BaseParams> = {
   denops: Denops;
   context: Context;
   options: DdcOptions;
@@ -18,7 +22,7 @@ export type SkipCompletionArguments<Params extends BaseUiParams> = {
   uiParams: Params;
 };
 
-export type ShowArguments<Params extends BaseUiParams> = {
+export type ShowArguments<Params extends BaseParams> = {
   denops: Denops;
   context: Context;
   options: DdcOptions;
@@ -28,7 +32,7 @@ export type ShowArguments<Params extends BaseUiParams> = {
   uiParams: Params;
 };
 
-export type HideArguments<Params extends BaseUiParams> = {
+export type HideArguments<Params extends BaseParams> = {
   denops: Denops;
   context: Context;
   options: DdcOptions;
@@ -36,7 +40,7 @@ export type HideArguments<Params extends BaseUiParams> = {
   uiParams: Params;
 };
 
-export type VisibleArguments<Params extends BaseUiParams> = {
+export type VisibleArguments<Params extends BaseParams> = {
   denops: Denops;
   context: Context;
   options: DdcOptions;
@@ -44,7 +48,7 @@ export type VisibleArguments<Params extends BaseUiParams> = {
   uiParams: Params;
 };
 
-export abstract class BaseUi<Params extends BaseUiParams> {
+export abstract class BaseUi<Params extends BaseParams> {
   name = "";
   isInitialized = false;
   apiVersion = 2;

--- a/denops/ddc/context.ts
+++ b/denops/ddc/context.ts
@@ -1,7 +1,5 @@
 import type {
-  BaseFilterParams,
-  BaseSourceParams,
-  BaseUiParams,
+  BaseParams,
   Context,
   DdcEvent,
   DdcOptions,
@@ -42,9 +40,9 @@ function overwrite<T>(a: T, b: Partial<T>): T {
 export const mergeUiOptions: Merge<UiOptions> = overwrite;
 export const mergeSourceOptions: Merge<SourceOptions> = overwrite;
 export const mergeFilterOptions: Merge<FilterOptions> = overwrite;
-export const mergeUiParams: Merge<BaseUiParams> = overwrite;
-export const mergeSourceParams: Merge<BaseSourceParams> = overwrite;
-export const mergeFilterParams: Merge<BaseFilterParams> = overwrite;
+export const mergeUiParams: Merge<BaseParams> = overwrite;
+export const mergeSourceParams: Merge<BaseParams> = overwrite;
+export const mergeFilterParams: Merge<BaseParams> = overwrite;
 
 export type ContextCallback =
   | string

--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -409,10 +409,8 @@ export class Ddc {
       return true;
     }
 
-    const [ui, uiOptions, uiParams] = await getUi(
+    const [ui, uiOptions, uiParams] = await this.#getUi(
       denops,
-      this.#loader,
-      this,
       context,
       options,
     );
@@ -509,10 +507,8 @@ export class Ddc {
       return;
     }
 
-    const [ui, uiOptions, uiParams] = await getUi(
+    const [ui, uiOptions, uiParams] = await this.#getUi(
       denops,
-      this.#loader,
-      this,
       context,
       options,
     );
@@ -540,10 +536,8 @@ export class Ddc {
     context: Context,
     options: DdcOptions,
   ) {
-    const [ui, uiOptions, uiParams] = await getUi(
+    const [ui, uiOptions, uiParams] = await this.#getUi(
       denops,
-      this.#loader,
-      this,
       context,
       options,
     );
@@ -571,10 +565,8 @@ export class Ddc {
       return true;
     }
 
-    const [ui, uiOptions, uiParams] = await getUi(
+    const [ui, uiOptions, uiParams] = await this.#getUi(
       denops,
-      this.#loader,
-      this,
       context,
       options,
     );
@@ -593,6 +585,35 @@ export class Ddc {
         uiParams,
       })
       : true;
+  }
+
+  async #getUi(
+    denops: Denops,
+    context: Context,
+    options: DdcOptions,
+  ): Promise<[BaseUi<BaseParams> | undefined, UiOptions, BaseParams]> {
+    const [ui, uiOptions, uiParams] = await getUi(
+      denops,
+      this.#loader,
+      options,
+    );
+    if (ui !== this.currentUi) {
+      // UI is changed
+      if (this.currentUi) {
+        await this.currentUi.hide({
+          denops,
+          context,
+          options,
+          uiOptions: this.currentUiOptions,
+          uiParams: this.currentUiParams,
+        });
+      }
+
+      this.currentUi = ui;
+      this.currentUiOptions = uiOptions;
+      this.currentUiParams = uiParams;
+    }
+    return [ui, uiOptions, uiParams];
   }
 }
 

--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -1,6 +1,5 @@
 import type {
-  BaseUi,
-  BaseUiParams,
+  BaseParams,
   CallbackContext,
   Context,
   DdcEvent,
@@ -14,7 +13,7 @@ import type {
 } from "./types.ts";
 import { defaultDummy } from "./context.ts";
 import type { Loader } from "./loader.ts";
-import { defaultUiOptions } from "./base/ui.ts";
+import { type BaseUi, defaultUiOptions } from "./base/ui.ts";
 import { defaultSourceOptions } from "./base/source.ts";
 import {
   callFilterFilter,
@@ -46,9 +45,9 @@ type DdcResult = {
 };
 
 export class Ddc {
-  currentUi: BaseUi<BaseUiParams> | undefined = undefined;
+  currentUi: BaseUi<BaseParams> | undefined = undefined;
   currentUiOptions: UiOptions = defaultUiOptions();
-  currentUiParams: BaseUiParams = defaultDummy();
+  currentUiParams: BaseParams = defaultDummy();
   visibleUi = false;
 
   #loader: Loader;
@@ -134,7 +133,6 @@ export class Ddc {
         denops,
         context,
         onCallback,
-        this.#loader,
         options,
         o,
         p,

--- a/denops/ddc/ext.ts
+++ b/denops/ddc/ext.ts
@@ -1,10 +1,5 @@
 import type {
-  BaseFilter,
-  BaseFilterParams,
-  BaseSource,
-  BaseSourceParams,
-  BaseUi,
-  BaseUiParams,
+  BaseParams,
   Context,
   DdcGatherItems,
   DdcItem,
@@ -34,9 +29,9 @@ import {
 import type { Loader } from "./loader.ts";
 import type { Ddc } from "./ddc.ts";
 import { isDdcCallbackCancelError } from "./callback.ts";
-import { defaultUiOptions } from "./base/ui.ts";
-import { defaultSourceOptions } from "./base/source.ts";
-import { defaultFilterOptions } from "./base/filter.ts";
+import { type BaseUi, defaultUiOptions } from "./base/ui.ts";
+import { type BaseSource, defaultSourceOptions } from "./base/source.ts";
+import { type BaseFilter, defaultFilterOptions } from "./base/filter.ts";
 import { printError } from "./utils.ts";
 
 import type { Denops } from "jsr:@denops/std@~7.1.0";
@@ -51,9 +46,9 @@ export async function getUi(
   options: DdcOptions,
 ): Promise<
   [
-    BaseUi<BaseUiParams> | undefined,
+    BaseUi<BaseParams> | undefined,
     UiOptions,
-    BaseUiParams,
+    BaseParams,
   ]
 > {
   if (options.ui.length === 0) {
@@ -115,9 +110,9 @@ export async function getSource(
   userSource: UserSource,
 ): Promise<
   [
-    BaseSource<BaseSourceParams> | undefined,
+    BaseSource<BaseParams> | undefined,
     SourceOptions,
-    BaseSourceParams,
+    BaseParams,
   ]
 > {
   const name = source2Name(userSource);
@@ -149,7 +144,6 @@ export async function getSource(
     denops,
     sourceOptions,
     sourceParams,
-    loader,
   );
 
   return [source, sourceOptions, sourceParams];
@@ -162,9 +156,9 @@ export async function getFilter(
   userFilter: UserFilter,
 ): Promise<
   [
-    BaseFilter<BaseFilterParams> | undefined,
+    BaseFilter<BaseParams> | undefined,
     FilterOptions,
-    BaseFilterParams,
+    BaseParams,
   ]
 > {
   const name = filter2Name(userFilter);
@@ -224,7 +218,6 @@ export async function getPreviewer(
     options,
     sourceOptions,
     sourceParams,
-    loader,
     item,
     previewContext,
   });
@@ -363,7 +356,6 @@ export async function onEvent(
     await callSourceOnEvent(
       source,
       denops,
-      loader,
       context,
       onCallback,
       options,
@@ -421,7 +413,6 @@ export async function onCompleteDone(
   await callSourceOnCompleteDone(
     source,
     denops,
-    loader,
     context,
     onCallback,
     options,
@@ -431,10 +422,10 @@ export async function onCompleteDone(
   );
 }
 
-function uiArgs<Params extends BaseUiParams>(
+function uiArgs<Params extends BaseParams>(
   options: DdcOptions,
   ui: BaseUi<Params>,
-): [UiOptions, BaseUiParams] {
+): [UiOptions, BaseParams] {
   const o = foldMerge(
     mergeUiOptions,
     defaultUiOptions,
@@ -448,13 +439,13 @@ function uiArgs<Params extends BaseUiParams>(
 }
 
 function sourceArgs<
-  Params extends BaseSourceParams,
+  Params extends BaseParams,
   UserData extends unknown,
 >(
   source: BaseSource<Params, UserData> | null,
   options: DdcOptions,
   userSource: UserSource | null,
-): [SourceOptions, BaseSourceParams] {
+): [SourceOptions, BaseParams] {
   // Convert type
   if (typeof userSource === "string") {
     userSource = {
@@ -485,12 +476,12 @@ function sourceArgs<
 }
 
 function filterArgs<
-  Params extends BaseFilterParams,
+  Params extends BaseParams,
 >(
   filter: BaseFilter<Params>,
   options: DdcOptions,
   userFilter: UserFilter,
-): [FilterOptions, BaseFilterParams] {
+): [FilterOptions, BaseParams] {
   // Convert type
   if (typeof userFilter === "string") {
     userFilter = {
@@ -521,10 +512,10 @@ function filterArgs<
 }
 
 async function checkUiOnInit(
-  ui: BaseUi<BaseUiParams>,
+  ui: BaseUi<BaseParams>,
   denops: Denops,
   uiOptions: UiOptions,
-  uiParams: BaseUiParams,
+  uiParams: BaseParams,
 ) {
   if (ui.isInitialized) {
     return;
@@ -548,11 +539,10 @@ async function checkUiOnInit(
 }
 
 async function checkSourceOnInit(
-  source: BaseSource<BaseSourceParams>,
+  source: BaseSource<BaseParams>,
   denops: Denops,
   sourceOptions: SourceOptions,
-  sourceParams: BaseSourceParams,
-  loader: Loader,
+  sourceParams: BaseParams,
 ) {
   if (source.isInitialized) {
     return;
@@ -563,7 +553,6 @@ async function checkSourceOnInit(
       denops,
       sourceOptions,
       sourceParams,
-      loader,
     });
 
     source.isInitialized = true;
@@ -585,10 +574,10 @@ async function checkSourceOnInit(
 }
 
 async function checkFilterOnInit(
-  filter: BaseFilter<BaseFilterParams>,
+  filter: BaseFilter<BaseParams>,
   denops: Denops,
   filterOptions: FilterOptions,
-  filterParams: BaseFilterParams,
+  filterParams: BaseParams,
 ) {
   if (filter.isInitialized) {
     return;
@@ -612,14 +601,13 @@ async function checkFilterOnInit(
 }
 
 async function callSourceOnEvent(
-  source: BaseSource<BaseSourceParams>,
+  source: BaseSource<BaseParams>,
   denops: Denops,
-  loader: Loader,
   context: Context,
   onCallback: OnCallback,
   options: DdcOptions,
   sourceOptions: SourceOptions,
-  sourceParams: BaseSourceParams,
+  sourceParams: BaseParams,
 ) {
   if (!source.events?.includes(context.event)) {
     return;
@@ -633,7 +621,6 @@ async function callSourceOnEvent(
       options,
       sourceOptions,
       sourceParams,
-      loader,
     });
   } catch (e: unknown) {
     if (isDdcCallbackCancelError(e)) {
@@ -649,12 +636,11 @@ async function callSourceOnEvent(
 }
 
 async function callSourceOnCompleteDone<
-  Params extends BaseSourceParams,
+  Params extends BaseParams,
   UserData extends unknown,
 >(
   source: BaseSource<Params, UserData>,
   denops: Denops,
-  loader: Loader,
   context: Context,
   onCallback: OnCallback,
   options: DdcOptions,
@@ -670,7 +656,6 @@ async function callSourceOnCompleteDone<
       options,
       sourceOptions,
       sourceParams,
-      loader,
       // This is preventing users from accessing the internal properties.
       // deno-lint-ignore no-explicit-any
       userData: userData as any,
@@ -689,21 +674,19 @@ async function callSourceOnCompleteDone<
 }
 
 export async function callSourceGetCompletePosition(
-  source: BaseSource<BaseSourceParams>,
+  source: BaseSource<BaseParams>,
   denops: Denops,
   context: Context,
   onCallback: OnCallback,
-  loader: Loader,
   options: DdcOptions,
   sourceOptions: SourceOptions,
-  sourceParams: BaseSourceParams,
+  sourceParams: BaseParams,
 ): Promise<number> {
   try {
     return await source.getCompletePosition({
       denops,
       context,
       onCallback,
-      loader,
       options,
       sourceOptions,
       sourceParams,
@@ -724,7 +707,7 @@ export async function callSourceGetCompletePosition(
 }
 
 export async function callSourceGather<
-  Params extends BaseSourceParams,
+  Params extends BaseParams,
   UserData extends unknown,
 >(
   source: BaseSource<Params, UserData>,
@@ -773,13 +756,13 @@ export async function callSourceGather<
 }
 
 async function callFilterOnEvent(
-  filter: BaseFilter<BaseFilterParams>,
+  filter: BaseFilter<BaseParams>,
   denops: Denops,
   context: Context,
   onCallback: OnCallback,
   options: DdcOptions,
   filterOptions: FilterOptions,
-  filterParams: BaseFilterParams,
+  filterParams: BaseParams,
 ) {
   if (!filter.events?.includes(context.event)) {
     return;
@@ -808,14 +791,14 @@ async function callFilterOnEvent(
 }
 
 export async function callFilterFilter(
-  filter: BaseFilter<BaseFilterParams>,
+  filter: BaseFilter<BaseParams>,
   denops: Denops,
   context: Context,
   onCallback: OnCallback,
   options: DdcOptions,
   sourceOptions: SourceOptions,
   filterOptions: FilterOptions,
-  filterParams: BaseFilterParams,
+  filterParams: BaseParams,
   completeStr: string,
   items: Item[],
 ): Promise<Item[]> {

--- a/denops/ddc/ext.ts
+++ b/denops/ddc/ext.ts
@@ -27,7 +27,6 @@ import {
   mergeUiParams,
 } from "./context.ts";
 import type { Loader } from "./loader.ts";
-import type { Ddc } from "./ddc.ts";
 import { isDdcCallbackCancelError } from "./callback.ts";
 import { type BaseUi, defaultUiOptions } from "./base/ui.ts";
 import { type BaseSource, defaultSourceOptions } from "./base/source.ts";
@@ -41,16 +40,12 @@ import { deadline } from "jsr:@std/async@~1.0.1/deadline";
 export async function getUi(
   denops: Denops,
   loader: Loader,
-  ddu: Ddc,
-  context: Context,
   options: DdcOptions,
-): Promise<
-  [
-    BaseUi<BaseParams> | undefined,
-    UiOptions,
-    BaseParams,
-  ]
-> {
+): Promise<[
+  BaseUi<BaseParams> | undefined,
+  UiOptions,
+  BaseParams,
+]> {
   if (options.ui.length === 0) {
     return [
       undefined,
@@ -76,27 +71,6 @@ export async function getUi(
   }
 
   const [uiOptions, uiParams] = uiArgs(options, ui);
-
-  if (ui !== ddu.currentUi) {
-    // UI is changed
-
-    if (ddu.currentUi) {
-      // Hide current UI
-      await ddu.currentUi.hide({
-        denops,
-        context,
-        options,
-        uiOptions: ddu.currentUiOptions,
-        uiParams: ddu.currentUiParams,
-      });
-
-      ddu.visibleUi = false;
-    }
-
-    ddu.currentUi = ui;
-    ddu.currentUiOptions = uiOptions;
-    ddu.currentUiParams = uiParams;
-  }
 
   await checkUiOnInit(ui, denops, uiOptions, uiParams);
 

--- a/denops/ddc/loader.ts
+++ b/denops/ddc/loader.ts
@@ -1,15 +1,13 @@
 import type {
-  BaseFilter,
-  BaseFilterParams,
-  BaseSource,
-  BaseSourceParams,
-  BaseUi,
-  BaseUiParams,
+  BaseParams,
   DdcExtType,
   FilterName,
   SourceName,
   UiName,
 } from "./types.ts";
+import type { BaseSource } from "./base/source.ts";
+import type { BaseFilter } from "./base/filter.ts";
+import type { BaseUi } from "./base/ui.ts";
 import { isDenoCacheIssueError } from "./utils.ts";
 import { mods } from "./_mods.js";
 
@@ -24,9 +22,9 @@ import { Lock } from "jsr:@core/asyncutil@~1.1.1/lock";
 import { toFileUrl } from "jsr:@std/path@~1.0.2/to-file-url";
 
 export class Loader {
-  #uis: Record<UiName, BaseUi<BaseUiParams>> = {};
-  #sources: Record<SourceName, BaseSource<BaseSourceParams>> = {};
-  #filters: Record<FilterName, BaseFilter<BaseFilterParams>> = {};
+  #uis: Record<UiName, BaseUi<BaseParams>> = {};
+  #sources: Record<SourceName, BaseSource<BaseParams>> = {};
+  #filters: Record<FilterName, BaseFilter<BaseParams>> = {};
   #aliases: Record<DdcExtType, Record<string, string>> = {
     ui: {},
     source: {},
@@ -134,13 +132,13 @@ export class Loader {
   getAlias(type: DdcExtType, name: string): string {
     return this.#aliases[type][name];
   }
-  getUi(name: UiName): BaseUi<BaseUiParams> {
+  getUi(name: UiName): BaseUi<BaseParams> {
     return this.#uis[name];
   }
-  getSource(name: SourceName): BaseSource<BaseSourceParams> {
+  getSource(name: SourceName): BaseSource<BaseParams> {
     return this.#sources[name];
   }
-  getFilter(name: FilterName): BaseFilter<BaseUiParams> {
+  getFilter(name: FilterName): BaseFilter<BaseParams> {
     return this.#filters[name];
   }
 

--- a/denops/ddc/types.ts
+++ b/denops/ddc/types.ts
@@ -1,18 +1,6 @@
 import type { AutocmdEvent } from "jsr:@denops/std@~7.1.0/autocmd";
-import type { BaseUiParams } from "./base/ui.ts";
-import type { BaseSourceParams } from "./base/source.ts";
-import type { BaseFilterParams } from "./base/filter.ts";
 
-export { BaseConfig } from "./base/config.ts";
-export { BaseUi } from "./base/ui.ts";
-export type { BaseUiParams } from "./base/ui.ts";
-export { BaseSource } from "./base/source.ts";
-export type { BaseSourceParams } from "./base/source.ts";
-export { BaseFilter } from "./base/filter.ts";
-export type { BaseFilterParams } from "./base/filter.ts";
-export type { Denops } from "jsr:@denops/std@~7.1.0";
-
-export { ContextBuilder } from "./context.ts";
+export type BaseParams = Record<string, unknown>;
 
 export type DdcExtType = "ui" | "source" | "filter";
 
@@ -40,13 +28,13 @@ export type Context = {
 export type UserSource = SourceName | {
   name: SourceName;
   options?: Partial<SourceOptions>;
-  params?: Partial<BaseSourceParams>;
+  params?: Partial<BaseParams>;
 };
 
 export type UserFilter = FilterName | {
   name: FilterName;
   options?: Partial<FilterOptions>;
-  params?: Partial<BaseFilterParams>;
+  params?: Partial<BaseParams>;
 };
 
 export type DdcOptions = {
@@ -55,16 +43,16 @@ export type DdcOptions = {
   backspaceCompletion: boolean;
   cmdlineSources: UserSource[] | Record<string, UserSource[]>;
   filterOptions: Record<FilterName, Partial<FilterOptions>>;
-  filterParams: Record<FilterName, Partial<BaseFilterParams>>;
+  filterParams: Record<FilterName, Partial<BaseParams>>;
   hideOnEvents: boolean;
   postFilters: UserFilter[];
   sourceOptions: Record<SourceName, Partial<SourceOptions>>;
-  sourceParams: Record<SourceName, Partial<BaseSourceParams>>;
+  sourceParams: Record<SourceName, Partial<BaseParams>>;
   sources: UserSource[];
   specialBufferCompletion: boolean;
   ui: UiName;
   uiOptions: Record<UiName, Partial<UiOptions>>;
-  uiParams: Record<UiName, Partial<BaseUiParams>>;
+  uiParams: Record<UiName, Partial<BaseParams>>;
 };
 
 export type UserOptions = Record<string, unknown>;

--- a/denops/ddc/types.ts
+++ b/denops/ddc/types.ts
@@ -1,3 +1,4 @@
+import type { Denops } from "jsr:@denops/std@~7.1.0";
 import type { AutocmdEvent } from "jsr:@denops/std@~7.1.0/autocmd";
 
 export type BaseParams = Record<string, unknown>;
@@ -24,6 +25,33 @@ export type Context = {
   mode: string;
   nextInput: string;
 };
+
+export type ContextCallback =
+  | string
+  | ((denops: Denops) => Promise<Partial<DdcOptions>>);
+
+export type ContextCallbacks = {
+  global: ContextCallback;
+  filetype: Record<string, ContextCallback>;
+  buffer: Record<number, ContextCallback>;
+};
+
+export interface ContextBuilder {
+  getGlobal(): Partial<DdcOptions>;
+  getFiletype(): Record<string, Partial<DdcOptions>>;
+  getContext(): ContextCallbacks;
+  getBuffer(): Record<number, Partial<DdcOptions>>;
+  getCurrent(denops: Denops): Promise<Partial<DdcOptions>>;
+  setGlobal(options: Partial<DdcOptions>): void;
+  setFiletype(ft: string, options: Partial<DdcOptions>): void;
+  setBuffer(bufnr: number, options: Partial<DdcOptions>): void;
+  setContextGlobal(callback: ContextCallback): void;
+  setContextFiletype(callback: ContextCallback, ft: string): void;
+  setContextBuffer(callback: ContextCallback, bufnr: number): void;
+  patchGlobal(options: Partial<DdcOptions>): void;
+  patchFiletype(ft: string, options: Partial<DdcOptions>): void;
+  patchBuffer(bufnr: number, options: Partial<DdcOptions>): void;
+}
 
 export type UserSource = SourceName | {
   name: SourceName;


### PR DESCRIPTION
- Stop re-exporting `Base*` classes in types.ts
- Unify `Base*Params` types to `BaseParams`
- Remove `loader` property from arguments of methods of `BaseSource`
- Split `ContextBuilder` type definition and implemention

Dependencies Graph:

![image](https://github.com/user-attachments/assets/4c523db6-f9b5-4f80-913d-bca55af0c00b)

Size reduction:

```console
$ deno info jsr:@shougo/ddc-vim@6.0.1/types | head -5
local: /Users/user/Library/Caches/deno/deps/https/jsr.io/a590a33b9a7e50e59f7ff1b4f3d8c9586c79b6750e94952894e3cc43c1d70844
emit: /Users/user/Library/Caches/deno/gen/https/jsr.io/a590a33b9a7e50e59f7ff1b4f3d8c9586c79b6750e94952894e3cc43c1d70844.js
type: TypeScript
dependencies: 292 unique
size: 1.93MB
$ deno info denops/ddc/types.ts | head -5
local: /Users/user/Library/Develops/github.com/4513ECHO/ddc.vim/denops/ddc/types.ts
type: TypeScript
dependencies: 10 unique
size: 26.5KB

```