### PR TITLE
refactor: remove unnecessary null check and Promise wrapping

### DIFF
--- a/denops/ddc/base/source.ts
+++ b/denops/ddc/base/source.ts
@@ -105,11 +105,10 @@ export abstract class BaseSource<
       args.sourceOptions.keywordPattern,
     );
 
-    const matchPos = args.context.input.search(
+    const completePos = args.context.input.search(
       new RegExp("(?:" + keywordPattern + ")$"),
     );
-    const completePos = matchPos !== null ? matchPos : -1;
-    return Promise.resolve(completePos);
+    return completePos;
   }
 
   abstract gather(


### PR DESCRIPTION
Since `String.search` always returns a `number` and `-1` when not matched, the null check is unnecessary and has been removed.
Also, as the method is async, there is no need to wrap the return value with Promise.resolve.