### PR TITLE
Fix completeStr calculation when completePos is negative

### DIFF
--- a/denops/ddc/ddc.ts
+++ b/denops/ddc/ddc.ts
@@ -150,7 +150,9 @@ export class Ddc {
         : (s.isBytePos && pos >= 0)
         ? byteposToCharpos(context.input, pos)
         : pos;
-      const completeStr = context.input.slice(completePos);
+      const completeStr = completePos < 0
+        ? ""
+        : context.input.slice(completePos);
 
       const invalidCompleteLength = context.event === "Manual"
         ? (completeStr.length < o.minManualCompleteLength ||


### PR DESCRIPTION
## Summary
- Fix potential issue where `completeStr` could have unexpected value when `completePos` is negative
- When `completePos < 0`, set `completeStr` to empty string instead of using slice with negative index

## Details
Previously, when `completePos` was negative, `context.input.slice(completePos)` would return characters from the end of the string due to JavaScript's slice behavior. Although this doesn't affect current behavior (since negative `completePos` causes early return), this change prevents potential future bugs.